### PR TITLE
Handle missing mail confirmation expiry date

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,7 +95,7 @@ class User < ApplicationRecord
 
   def mail_confirm!(mail_confirmation_token)
     return false if self.mail_confirmation_token != mail_confirmation_token
-    return false if self.mail_confirmation_expired_at < Time.current
+    return false if self.mail_confirmation_expired_at.nil? || self.mail_confirmation_expired_at < Time.current
 
     self.update(mail_confirmed_at: Time.current)
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -69,4 +69,30 @@ class UserTest < ActiveSupport::TestCase
     assert_nil user.mail_confirmed_at
     assert_equal :pending, user.current_mail_status
   end
+
+  test "メールアドレス承認(期限無し)" do
+    user = users(:user_manager)
+    user.mail = 'user_nil@example.com'
+    user.save!
+    user.update_column(:mail_confirmation_expired_at, nil)
+
+    result = user.mail_confirm!(user.mail_confirmation_token)
+
+    assert_not result
+    assert_nil user.mail_confirmed_at
+    assert_equal :pending, user.current_mail_status
+  end
+
+  test "メールアドレス承認(期限切れ)" do
+    user = users(:user_manager)
+    user.mail = 'user_expired@example.com'
+    user.save!
+    user.update_column(:mail_confirmation_expired_at, 1.day.ago)
+
+    result = user.mail_confirm!(user.mail_confirmation_token)
+
+    assert_not result
+    assert_nil user.mail_confirmed_at
+    assert_equal :expired, user.current_mail_status
+  end
 end


### PR DESCRIPTION
## Summary
- prevent errors when `mail_confirmation_expired_at` is missing by guarding in `User#mail_confirm!`
- add tests covering missing and expired mail confirmation expiration cases

## Testing
- `bundle exec rails test` *(fails: bundler command not found: rails)*
- `bundle exec rake test` *(fails: missing gems such as rails-8.0.2)*

------
https://chatgpt.com/codex/tasks/task_e_689bf09597c48324a547f725bff03be2