### PR TITLE
Handle HTTP redirects when checking topic URLs

### DIFF
--- a/app/jobs/news_reply_job.rb
+++ b/app/jobs/news_reply_job.rb
@@ -60,7 +60,8 @@ class NewsReplyJob < ApplicationJob
     res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
       http.head(uri.request_uri)
     end
-    res.is_a?(Net::HTTPSuccess)
+
+    res.is_a?(Net::HTTPSuccess) || res.is_a?(Net::HTTPRedirection)
   rescue StandardError
     false
   end


### PR DESCRIPTION
## Summary
- treat HTTP redirections as alive when verifying topic URLs in NewsReplyJob

## Testing
- `bundle exec rake test` *(fails: Could not find rails-8.0.2, pg-1.6.1-x86_64-linux, ... in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_689be13538e88324be9b1d588e71bf61