### PR TITLE
Add user role predicate tests

### DIFF
--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -33,6 +33,13 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
+  setup do
+    @admin   = users(:users1)
+    @manager = users(:user_manager)
+    @checker = users(:user_checker)
+    @user    = users(:user_user)
+    @visitor = users(:user_visitor)
+  end
   test "メールアドレス設定" do
     user = users(:user_manager)
     user.mail = 'user@example.com'
@@ -94,5 +101,41 @@ class UserTest < ActiveSupport::TestCase
     assert_not result
     assert_nil user.mail_confirmed_at
     assert_equal :expired, user.current_mail_status
+  end
+
+  test "権限別の判定" do
+    {
+      admin:   @admin,
+      manager: @manager,
+      checker: @checker,
+      user:    @user,
+      visitor: @visitor
+    }.each do |role, u|
+      assert_equal role == :admin,   u.admin?,   "#{role} admin?"
+      assert_equal role == :manager, u.manager?, "#{role} manager?"
+      assert_equal role == :checker, u.checker?, "#{role} checker?"
+      assert_equal role == :user,    u.user?,    "#{role} user?"
+      assert_equal role == :visitor, u.visitor?, "#{role} visitor?"
+    end
+  end
+
+  test "権限の複合判定" do
+    assert @admin.userable?
+    assert @manager.userable?
+    assert @checker.userable?
+    assert @user.userable?
+    assert_not @visitor.userable?
+
+    assert @admin.manageable?
+    assert @manager.manageable?
+    assert_not @checker.manageable?
+    assert_not @user.manageable?
+    assert_not @visitor.manageable?
+
+    assert @admin.checkable?
+    assert @manager.checkable?
+    assert @checker.checkable?
+    assert_not @user.checkable?
+    assert_not @visitor.checkable?
   end
 end


### PR DESCRIPTION
## Summary
- cover role predicates for admin, manager, checker, user, and visitor
- verify composite role checks for userable?, manageable?, and checkable?

## Testing
- `bin/rails test test/models/user_test.rb` *(fails: Could not find required gems)*

------
https://chatgpt.com/codex/tasks/task_e_689c781d2090832488da9bf7fc55f0d2