### PR TITLE
Add InitWorkTypeCacheJob test

### DIFF
--- a/test/jobs/init_work_type_cache_job_test.rb
+++ b/test/jobs/init_work_type_cache_job_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class InitWorkTypeCacheJobTest < ActiveJob::TestCase
+  test "Work.no_fixed(term).landable が呼ばれ、各レコードで regist_work_work_types が実行される" do
+    term = 2024
+    work1 = mock("work1")
+    work2 = mock("work2")
+    work1.expects(:regist_work_work_types)
+    work2.expects(:regist_work_work_types)
+
+    relation = mock("relation")
+    Work.expects(:no_fixed).with(term).returns(relation)
+    relation.expects(:landable).returns(relation)
+    relation.expects(:find_each).multiple_yields([work1], [work2])
+
+    perform_enqueued_jobs { InitWorkTypeCacheJob.perform_now(term) }
+  end
+
+  test "キュー名が default である" do
+    assert_equal "default", InitWorkTypeCacheJob.queue_name
+  end
+end


### PR DESCRIPTION
## Summary
- add unit test for InitWorkTypeCacheJob to ensure Work.no_fixed(term).landable is invoked and regist_work_work_types runs for each work
- verify job queue name is `default`

## Testing
- `bundle exec rails test test/jobs/init_work_type_cache_job_test.rb` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689c781ef89883249a1b598c3f652150