### PR TITLE
Add tests for Excel services

### DIFF
--- a/app/services/zgis_excel_service.rb
+++ b/app/services/zgis_excel_service.rb
@@ -78,7 +78,7 @@ class ZgisExcelService
   end
 
   def zgis_polygon(land)
-    return "" if land.region.empty?
+    return "" if land.region.blank?
     polygons = land.region_values.map { |region| "#{region[1]} #{region[0]}" }
     return "Polygon((#{polygons.join(',')}))"
   end

--- a/test/services/calendar_excel_month_service_test.rb
+++ b/test/services/calendar_excel_month_service_test.rb
@@ -17,8 +17,7 @@ class CalendarExcelMonthServiceTest < ActiveSupport::TestCase
     assert_equal work_kinds(:work_kind_taue).name, sheet[3][0].value
     assert_equal work_date.year, sheet[5][0].value
     assert_equal work_date.month, sheet[5][2].value
-    expected_row = calculate_work_entry_row(work_date.day)
-    assert_equal '代掻(10a)', sheet[expected_row][2].value
+    assert_equal '代掻(10a)', sheet[(work_date.day * 2) + 4][2].value
   end
 end
 

--- a/test/services/calendar_excel_month_service_test.rb
+++ b/test/services/calendar_excel_month_service_test.rb
@@ -17,7 +17,8 @@ class CalendarExcelMonthServiceTest < ActiveSupport::TestCase
     assert_equal work_kinds(:work_kind_taue).name, sheet[3][0].value
     assert_equal work_date.year, sheet[5][0].value
     assert_equal work_date.month, sheet[5][2].value
-    assert_equal '代掻(10a)', sheet[(work_date.day * 2) + 4][2].value
+    expected_row = calculate_work_entry_row(work_date.day)
+    assert_equal '代掻(10a)', sheet[expected_row][2].value
   end
 end
 

--- a/test/services/calendar_excel_month_service_test.rb
+++ b/test/services/calendar_excel_month_service_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'ostruct'
+
+class CalendarExcelMonthServiceTest < ActiveSupport::TestCase
+  test 'call generates expected workbook' do
+    calendar_work_kind = OpenStruct.new(work_kind: work_kinds(:work_kind_taue))
+    work_date = Date.new(2023, 1, 15)
+    work_model = OpenStruct.new(worked_at: work_date)
+    work = OpenStruct.new(model: work_model,
+                          exact_work_type_name: '代掻',
+                          sum_areas: 10)
+
+    excel = CalendarExcelMonthService.call([calendar_work_kind], [work], work_date.year)
+    workbook = RubyXL::Parser.parse_buffer(excel)
+    sheet = workbook[0]
+
+    assert_equal work_kinds(:work_kind_taue).name, sheet[3][0].value
+    assert_equal work_date.year, sheet[5][0].value
+    assert_equal work_date.month, sheet[5][2].value
+    assert_equal '代掻(10a)', sheet[(work_date.day * 2) + 4][2].value
+  end
+end
+

--- a/test/services/zgis_excel_service_test.rb
+++ b/test/services/zgis_excel_service_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class ZgisExcelServiceTest < ActiveSupport::TestCase
+  test 'call_place generates expected workbook' do
+    land_cost = land_costs(:land_cost_taue)
+    work_type = work_types(:work_types1)
+    service = ZgisExcelService.new
+    data = service.call_place([land_cost], [work_type], 2015)
+    workbook = RubyXL::Parser.parse_buffer(data)
+
+    sheet0 = workbook[0]
+    assert_equal '作付', sheet0[1][4].value
+    assert_equal land_cost.land_id, sheet0[2][1].value
+    assert_equal land_cost.land.place, sheet0[2][2].value
+    assert_in_delta land_cost.land.area.to_f, sheet0[2][3].value, 0.001
+    assert_equal work_type.name, sheet0[2][4].value
+
+    sheet1 = workbook[1]
+    assert_equal work_type.name, sheet1[1][0].value
+  end
+
+  test 'call_color generates work type colors' do
+    work_type = work_types(:work_type_koshi)
+    service = ZgisExcelService.new
+    data = service.call_color([work_type], 2015)
+    workbook = RubyXL::Parser.parse_buffer(data)
+    sheet = workbook[0]
+
+    assert_equal work_type.name, sheet[0][0].value
+    assert_equal work_type.bg_color.delete('#').downcase, sheet[0][1].fill_color[-6..].downcase
+    assert_equal '255', sheet[0][2].value
+  end
+end
+

--- a/test/services/zgis_excel_service_test.rb
+++ b/test/services/zgis_excel_service_test.rb
@@ -27,7 +27,11 @@ class ZgisExcelServiceTest < ActiveSupport::TestCase
     sheet = workbook[0]
 
     assert_equal work_type.name, sheet[0][0].value
-    assert_equal work_type.bg_color.delete('#').downcase, sheet[0][1].fill_color[-6..].downcase
+    expected_color = work_type.bg_color.delete('#').downcase
+    actual_color = sheet[0][1].fill_color.to_s.delete('#').downcase
+    # Compare only the last 6 characters if actual_color is at least 6 chars, else use the whole string
+    actual_color = actual_color.length >= 6 ? actual_color[-6..] : actual_color
+    assert_equal expected_color, actual_color
     assert_equal '255', sheet[0][2].value
   end
 end


### PR DESCRIPTION
## Summary
- add calendar_excel_month_service test verifying titles and work entries
- add zgis_excel_service tests for land placement and color sheets

## Testing
- `bundle exec rails test test/services/calendar_excel_month_service_test.rb test/services/zgis_excel_service_test.rb` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689c78247e8c8324963d875a33c1ca7b