### PR TITLE
Add experimental QR login block and QrLoginSession endpoints

### DIFF
--- a/app/controllers/qr_login_sessions_controller.rb
+++ b/app/controllers/qr_login_sessions_controller.rb
@@ -1,0 +1,34 @@
+class QrLoginSessionsController < ApplicationController
+  skip_before_action :restrict_remote_ip, only: [:create, :qrcode]
+
+  def create
+    qr_login_session = QrLoginSession.create!
+
+    render json: {
+      token: qr_login_session.token,
+      expires_at: qr_login_session.expires_at.iso8601
+    }
+  end
+
+  def qrcode
+    qr_login_session = QrLoginSession.find_by!(token: params[:token])
+    return head :gone if qr_login_session.expired?
+
+    qr = RQRCode::QRCode.new(qr_payload(qr_login_session))
+    svg = qr.as_svg(
+      offset: 0,
+      color: '000',
+      shape_rendering: 'crispEdges',
+      module_size: 6,
+      standalone: true
+    )
+
+    render plain: svg, content_type: 'image/svg+xml'
+  end
+
+  private
+
+  def qr_payload(qr_login_session)
+    qr_login_session.token
+  end
+end

--- a/app/javascript/controllers/qr_login_controller.js
+++ b/app/javascript/controllers/qr_login_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["image", "status"]
+
+  async generate() {
+    this.setStatus("QRを生成しています…")
+
+    try {
+      const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+      const response = await fetch("/qr_login_sessions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrfToken,
+          "Accept": "application/json"
+        },
+        body: JSON.stringify({})
+      })
+
+      if (!response.ok) throw new Error("QRセッションの作成に失敗しました")
+
+      const data = await response.json()
+      this.imageTarget.src = `/qr_login_sessions/${data.token}/qrcode.svg`
+      this.imageTarget.hidden = false
+      this.setStatus(`有効期限: ${new Date(data.expires_at).toLocaleString("ja-JP")}`)
+    } catch (error) {
+      this.setStatus(error.message)
+    }
+  }
+
+  setStatus(message) {
+    if (this.hasStatusTarget) this.statusTarget.textContent = message
+  }
+}

--- a/app/models/qr_login_session.rb
+++ b/app/models/qr_login_session.rb
@@ -1,0 +1,24 @@
+class QrLoginSession < ApplicationRecord
+  enum :status, { pending: 0, approved: 1, consumed: 2, expired: 3 }, default: :pending
+
+  before_validation :ensure_token, on: :create
+  before_validation :set_default_expires_at, on: :create
+
+  validates :token, presence: true, uniqueness: true,
+                    format: { with: /\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i }
+  validates :expires_at, presence: true
+
+  def expired?
+    expires_at <= Time.current
+  end
+
+  private
+
+  def ensure_token
+    self.token ||= SecureRandom.uuid
+  end
+
+  def set_default_expires_at
+    self.expires_at ||= 5.minutes.from_now
+  end
+end

--- a/app/views/qr_login/_block.html.erb
+++ b/app/views/qr_login/_block.html.erb
@@ -1,0 +1,19 @@
+<div class="mt-3" data-controller="qr-login">
+  <button class="btn btn-outline-primary w-100"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#qrLoginCollapse"
+          aria-expanded="false"
+          aria-controls="qrLoginCollapse"
+          data-action="click->qr-login#generate">
+    QRを生成
+  </button>
+
+  <div class="collapse mt-3" id="qrLoginCollapse">
+    <div class="card card-body text-center">
+      <p class="mb-2">このQRをモバイルアプリで読み取ってください。</p>
+      <img hidden data-qr-login-target="image" class="img-fluid mx-auto border" style="max-width: 320px;" alt="QRログイン用QRコード" />
+      <small class="text-muted mt-2" data-qr-login-target="status"></small>
+    </div>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -49,6 +49,8 @@
                         </div>
                         <%= submit_tag '認証する', class: "btn btn-success btn-lg float-end" %>
                       <% end %>
+
+                      <%= render "qr_login/block" %>
                     </div>
                   </div>
                 </div>

--- a/config/routes/all_routes.rb
+++ b/config/routes/all_routes.rb
@@ -89,6 +89,8 @@ resources :schedules, except: [:show] do
 end
 resources :broccoli, param: "work_id", only: [:edit, :update, :destroy]
 resources :sessions, only: [:new, :create, :index]
+resources :qr_login_sessions, only: [:create], param: :token
+get 'qr_login_sessions/:token/qrcode.svg', to: 'qr_login_sessions#qrcode', as: :qr_login_session_qrcode
 resources :machine_types, except: [:show]
 resources :chemical_types, except: [:show]
 resources :work_kinds, except: [:show]

--- a/db/migrate/20260224090000_create_qr_login_sessions.rb
+++ b/db/migrate/20260224090000_create_qr_login_sessions.rb
@@ -1,0 +1,15 @@
+class CreateQrLoginSessions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :qr_login_sessions do |t|
+      t.string :token, null: false
+      t.datetime :expires_at, null: false
+      t.integer :status, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :qr_login_sessions, :token, unique: true
+    add_index :qr_login_sessions, :expires_at
+    add_index :qr_login_sessions, :status
+  end
+end


### PR DESCRIPTION
### Motivation
- Provide an experimental QR-based login option on the existing login page while keeping the current ID/PW flow unchanged.
- Deliver a minimal server-side session + QR generation flow so the front-end can request a token and display a QR (approve/consume and realtime subscription to be implemented later).

### Description
- Add a reusable partial `app/views/qr_login/_block.html.erb` and embed it in the existing login page `app/views/sessions/new.html.erb` using Bootstrap 5 `collapse` for the UI and a button to trigger QR generation.
- Implement `QrLoginSession` model (`app/models/qr_login_session.rb`) with UUIDv4 `token` generation, `expires_at` default to 5 minutes, `status` enum (`pending/approved/consumed/expired`), and an `expired?` helper, plus the corresponding migration `db/migrate/20260224090000_create_qr_login_sessions.rb`.
- Add `QrLoginSessionsController` (`app/controllers/qr_login_sessions_controller.rb`) with `create` (POST `/qr_login_sessions`) returning `{ token, expires_at }` JSON and `qrcode` (GET `/qr_login_sessions/:token/qrcode.svg`) that validates the token and returns an SVG QR via `RQRCode`, and skip the existing `restrict_remote_ip` before_action for these actions.
- Add routes for the session creation and QR SVG (`config/routes/all_routes.rb`) and a Stimulus controller `app/javascript/controllers/qr_login_controller.js` that POSTs to create a session, then sets the `<img>` src to the returned `/qrcode.svg` URL.

### Testing
- Ran Ruby syntax checks: `ruby -c app/controllers/qr_login_sessions_controller.rb`, `ruby -c app/models/qr_login_session.rb`, and `ruby -c db/migrate/20260224090000_create_qr_login_sessions.rb`, all succeeded.
- Attempted `bin/rails routes | rg qr_login_sessions`, which could not run in this environment due to missing Bundler gems, so route resolution was not validated here.
- Attempted a Playwright screenshot of the running app to visually verify the login page, which failed because the application server was not running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da2a382608324801aa2adf7d84f60)