### PR TITLE
Add GitHub Actions CI workflow for Rails (minitest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: groonga/pgroonga:latest-debian-16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
### Motivation
- Provide CI that runs the Rails minitest suite on `push` and `pull_request` to catch regressions automatically.
- Detect project settings (Ruby and DB) to ensure the workflow uses the correct runtime and service configuration.

### Description
- Add a new workflow file at `.github/workflows/ci.yml` that runs on `push` and `pull_request` and provisions a PostgreSQL service for tests.
- Use `ruby/setup-ruby@v1` with `bundler-cache: true`, set `RAILS_ENV=test`, and run `bundle exec rails db:prepare` followed by `bundle exec rails test` to execute minitest.
- The workflow reads `config/database.yml` at runtime to detect the test adapter and fails early if it is not `postgresql` so service mismatch is avoided.
- Changed/added files:
  - `.github/workflows/ci.yml` (new)

### Created `.github/workflows/ci.yml` (full contents)
```yaml
name: CI

on:
  push:
  pull_request:

jobs:
  test:
    runs-on: ubuntu-latest

    services:
      postgres:
        image: postgres:16
        env:
          POSTGRES_USER: postgres
          POSTGRES_PASSWORD: postgres
          POSTGRES_DB: farm2_test
        ports:
          - 5432:5432
        options: >-
          --health-cmd "pg_isready -U postgres -d farm2_test"
          --health-interval 10s
          --health-timeout 5s
          --health-retries 5

    env:
      RAILS_ENV: test
      DATABASE_URL: postgres://postgres:postgres@localhost:5432/farm2_test

    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Detect DB adapter from config/database.yml
        id: db
        shell: bash
        run: |
          adapter=$(ruby -ryaml -rerb -e 'config = YAML.safe_load(ERB.new(File.read("config/database.yml")).result, aliases: true) || {}; test_cfg = config["test"] || config["default"] || {}; puts(test_cfg["adapter"].to_s)')
          if [[ -z "$adapter" ]]; then
            echo "Could not determine DB adapter from config/database.yml" >&2
            exit 1
          fi
          echo "adapter=$adapter" >> "$GITHUB_OUTPUT"
          echo "Detected adapter: $adapter"

      - name: Ensure service matches adapter
        if: steps.db.outputs.adapter != 'postgresql'
        run: |
          echo "This workflow currently provisions PostgreSQL service, but adapter is '${{ steps.db.outputs.adapter }}'." >&2
          exit 1

      - name: Set up Ruby
        uses: ruby/setup-ruby@v1
        with:
          bundler-cache: true

      - name: Prepare database
        run: bundle exec rails db:prepare

      - name: Run tests
        run: bundle exec rails test
```

### Testing
- Ran repository inspection commands to discover Ruby and DB configuration, which reported Ruby `4.0.1` and `test` adapter `postgresql`, and these checks succeeded.
- Executed the Ruby script that parses `config/database.yml` to confirm adapter, database name, and host, and it returned `postgresql`, `farm2_test`, and `db` successfully.
- Created the workflow file and verified it is present in `.github/workflows/ci.yml`; no automated CI run was performed here but the workflow is configured to run on `push` and `pull_request`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699daec4539083248e89f62d230af8b7)