### PR TITLE
Add GitHub Actions CI workflow for Rails tests with PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/farm2_test
       GOOGLE_CLIENT_ID: ci-dummy-client-id
       GOOGLE_CLIENT_SECRET: ci-dummy-client-secret
+      MAIL_ADDRESS: ci-test@example.com
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Motivation

- Add a CI workflow to run the Rails test suite in GitHub Actions with a reproducible PostgreSQL test database and required environment variables.

### Description

- Add `.github/workflows/ci.yml` which provisions a PostgreSQL 16 service and exports `DATABASE_URL`, `RAILS_ENV`, and dummy Google OAuth credentials for CI.
- Add a step that detects the DB adapter from `config/database.yml` using a small Ruby snippet and fails if the repository expects a non-PostgreSQL adapter so the service matches the app.
- Set up Ruby using `ruby/setup-ruby@v1` with bundler cache, create required `log` files, run `bundle exec rails db:prepare`, and run the test suite with `bundle exec rails test`.

### Testing

- The workflow is configured to run the Rails test suite via `bundle exec rails test` inside the CI job.  
- No CI run results are included in this change, so automated test results are not available in this PR.  
- Local or subsequent CI executions are required to verify that `rails test` passes against the provisioned PostgreSQL service.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699daec4539083248e89f62d230af8b7)