### PR TITLE
#942 bootstrap の非推奨警告対応

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,4 @@
-// Custom Bootstrap variables should be configured before this use.
+// Custom Bootstrap variables should be configured via `@use "bootstrap" with (...)`
+// (or by splitting `@use` statements to expose variables/mixins) rather than by
+// defining variables earlier in this file.
 @use "bootstrap";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,2 @@
-// Custom Bootstrap variables should be defined before this import.
-@import "bootstrap";
+// Custom Bootstrap variables should be configured before this use.
+@use "bootstrap";


### PR DESCRIPTION
```
Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
2 │ @import "bootstrap";
  │         ^^^^^^^^^^^
  ╵
    app/assets/stylesheets/application.scss 2:9  root stylesheet
```