### PR TITLE
#959 日報入力のときのタスク表示条件

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,12 +92,12 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     benchmark (0.5.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
     bootstrap (5.3.8)
       popper_js (>= 2.11.8, < 3)
     builder (3.3.0)
-    bullet (8.1.0)
+    bullet (8.1.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     capybara (3.40.0)
@@ -153,7 +153,7 @@ GEM
       request_store (>= 1.0)
       ruby2_keywords
     drb (2.2.3)
-    erb (6.0.3)
+    erb (6.0.4)
     erubi (1.13.1)
     execjs (2.10.1)
     faraday (2.14.1)
@@ -183,7 +183,7 @@ GEM
       logger
     hkdf (0.3.0)
     holiday_jp (0.8.1)
-    http-cookie (1.1.4)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
@@ -201,7 +201,7 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.8.2)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
@@ -209,7 +209,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.3)
+    json (2.19.4)
     jwt (3.1.2)
       base64
     kaminari (1.2.2)
@@ -267,7 +267,7 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (6.0.4)
+    minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
     minitest-mock (5.27.0)
@@ -328,7 +328,7 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    propshaft (1.3.1)
+    propshaft (1.3.2)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -125,6 +125,7 @@ class Task < ApplicationRecord
     new_work_link = task_table[:office_role].eq(work.work_type.office_role) # 役割が一致
               .and(task_table[:office_role].not_eq(Task.office_roles[:none])) # 役割が「なし」ではない
               .and(task_table[:assignee_id].in(worker_ids_subq)) # 作業者が担当者に含まれる
+              .and(task_table[:planned_start_on].lteq(work.worked_at)) # 作業日までに開始予定
 
     base = where(task_status_id: TaskStatus.workable_ids).where(new_work_link)
     base.select(task_table[Arel.star])

--- a/test/controllers/works/tasks_controller_test.rb
+++ b/test/controllers/works/tasks_controller_test.rb
@@ -17,6 +17,17 @@ class Works::TasksControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "作業変更(タスク)(表示)(開始予定日前のタスクは表示しない)" do
+    work = works(:work_task_work)
+    tasks(:task33).update!(planned_start_on: work.worked_at + 1.day)
+
+    get new_work_task_path(work_id: work)
+
+    assert_response :success
+    assert_match "task31", @response.body
+    assert_no_match "task33", @response.body
+  end
+
   test "作業変更(タスク)(更新)" do
     work = works(:work_task_work)
     task1 = tasks(:task31) 


### PR DESCRIPTION
作業者から遷移したときのタスク入力の時、開始日を表示条件に含める。