### PR TITLE
#998 ApplicationController の認証・認可・例外処理を整理する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -123,7 +123,7 @@ class ApplicationController < ActionController::Base
       logger.error "No exception object given (manual trigger)"
     end
     logger.error "Request: #{request.method} #{request.fullpath} from #{request.remote_ip}"
-    logger.error "Params: #{request.params}"
+    logger.error "Params: #{request.filtered_parameters}"
     logger.error "User: #{@current_user&.id}"
 
     render file: Rails.public_path.join('503.html'), layout: false, status: :service_unavailable

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,12 +7,12 @@ class ApplicationController < ActionController::Base
   include SessionsHelper
   helper_method :menu_name, :prefixed_path
 
-  before_action :restrict_remote_ip
-  before_action :enforce_access_target, if: :user_present?
+  before_action :authenticate_user!
+  before_action :check_access_target!, if: :user_signed_in?
   before_action :set_term, if: :user_present?
 
   unless Rails.env.development? || Rails.env.test?
-    rescue_from StandardError, with: :handle_error
+    rescue_from StandardError, with: :handle_internal_error
   end
 
   protected
@@ -54,7 +54,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def permit_admin
+  def authorize_admin!
     return to_error_path unless current_user.admin?
   end
 
@@ -75,7 +75,7 @@ class ApplicationController < ActionController::Base
     @term = current_organization.term
   end
 
-  def enforce_access_target
+  def check_access_target!
     target = session[:access_target].to_s.upcase
     return true if target.blank? || target == "PC"
 
@@ -99,18 +99,22 @@ class ApplicationController < ActionController::Base
     path.match?(%r{\A(?:/[^/]+)?#{escaped_prefix}(?:/|\z)})
   end
 
-  def restrict_remote_ip
-    if session[:user_id].nil? 
+  def authenticate_user!
+    if session[:user_id].nil?
       redirect_to prefixed_path(root_path)
       return false
     end
   end
 
-  def permit_this_term
+  def authorize_current_term!
     return to_error_path unless this_term?
   end
 
   def to_error_path(exception = nil)
+    render_service_unavailable(exception)
+  end
+
+  def render_service_unavailable(exception = nil)
     logger.error "[503] Service Unavailable"
     if exception
       logger.error "Exception: #{exception.class} - #{exception.message}"
@@ -127,6 +131,10 @@ class ApplicationController < ActionController::Base
 
   def user_present?
     session[:user_id].present?
+  end
+
+  def user_signed_in?
+    user_present?
   end
 
   def menu_name
@@ -180,13 +188,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def handle_error(exception = nil)
+  def handle_internal_error(exception = nil)
     logger.error "[500] Internal Server Error"
 
     logger.error({
-      error: exception.class.name,
-      message: exception.message,
-      stack_trace: exception.backtrace.take(5),
+      error: exception&.class&.name,
+      message: exception&.message,
+      stack_trace: exception&.backtrace&.take(5),
       path: request.fullpath,
       time: Time.current,
       severity: :ERROR

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,5 +1,5 @@
 class HealthController < ApplicationController
-  skip_before_action :restrict_remote_ip
+  skip_before_action :authenticate_user!
 
   def index
     Rails.application.config.access_logger.info "GS-Health Check"

--- a/app/controllers/ip_lists_controller.rb
+++ b/app/controllers/ip_lists_controller.rb
@@ -1,5 +1,7 @@
 class IpListsController < ApplicationController
   layout false
+  skip_before_action :authenticate_user!
+  before_action :check_ip_access!
   before_action :set_ip, only: [:edit, :update]
   before_action :set_return_to
 
@@ -38,7 +40,7 @@ class IpListsController < ApplicationController
 
   private
 
-  def restrict_remote_ip
+  def check_ip_access!
     if IpList.white_list.any? { |ip| ip.include?(request.remote_ip) }
       redirect_to @return_to.presence || root_path and return
     elsif IpList.black_list.any? { |ip| ip.include?(request.remote_ip) }

--- a/app/controllers/ip_lists_controller.rb
+++ b/app/controllers/ip_lists_controller.rb
@@ -1,6 +1,6 @@
 class IpListsController < ApplicationController
   layout false
-  skip_before_action :authenticate_user!
+  skip_before_action :authenticate_user!, only: %i[new create edit update]
   before_action :set_return_to
   before_action :check_ip_access!
   before_action :set_ip, only: [:edit, :update]

--- a/app/controllers/ip_lists_controller.rb
+++ b/app/controllers/ip_lists_controller.rb
@@ -1,9 +1,9 @@
 class IpListsController < ApplicationController
   layout false
   skip_before_action :authenticate_user!
+  before_action :set_return_to
   before_action :check_ip_access!
   before_action :set_ip, only: [:edit, :update]
-  before_action :set_return_to
 
   def new; end
 

--- a/app/controllers/land_costs_controller.rb
+++ b/app/controllers/land_costs_controller.rb
@@ -1,7 +1,7 @@
 class LandCostsController < ApplicationController
   include PermitManager
 
-  before_action :permit_this_term
+  before_action :authorize_current_term!
   before_action :set_work_types, only: [:index]
   before_action :set_land_cost, only: [:index]
   before_action :set_land, only: [:edit, :update]

--- a/app/controllers/minutes_controller.rb
+++ b/app/controllers/minutes_controller.rb
@@ -2,7 +2,7 @@ class MinutesController < ApplicationController
   before_action :set_minute, only: [:show, :destroy]
   before_action :permit_checker, only: [:index, :create, :destroy]
   before_action :permit_show, only: [:show]
-  skip_before_action :restrict_remote_ip, only: [:show]
+  skip_before_action :authenticate_user!, only: [:show]
 
   def index
     @schedules = ScheduleDecorator.decorate_collection(Schedule.for_organization(current_organization).for_minute)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,5 +1,5 @@
 class OrganizationsController < ApplicationController
-  before_action :permit_admin, only: [:edit, :update]
+  before_action :authorize_admin!, only: [:edit, :update]
   before_action :set_masters, only: [:edit]
   before_action :set_organization
   helper GmapHelper

--- a/app/controllers/personal_calendars_controller.rb
+++ b/app/controllers/personal_calendars_controller.rb
@@ -1,4 +1,6 @@
 class PersonalCalendarsController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def show
     @worker = User.find_by(token: params[:token])&.worker
     if @worker
@@ -15,8 +17,6 @@ class PersonalCalendarsController < ApplicationController
   end
 
   private
-
-  def restrict_remote_ip; end
 
   def worked_from
     Date.new(Time.zone.today.year - 1, 1, 1)

--- a/app/controllers/personal_informations_controller.rb
+++ b/app/controllers/personal_informations_controller.rb
@@ -1,4 +1,5 @@
 class PersonalInformationsController < ApplicationController
+  skip_before_action :authenticate_user!
   before_action :set_worker
   layout 'sm'
 
@@ -15,8 +16,6 @@ class PersonalInformationsController < ApplicationController
   end
 
   protected
-
-  def restrict_remote_ip; end
 
   def set_worker
     @current_user = User.find_by(token: params[:token] || params[:personal_information_token])

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,6 +1,6 @@
 class PlansController < ApplicationController
   include PermitManager
-  before_action :permit_this_term
+  before_action :authorize_current_term!
   before_action :save_system
 
   protected

--- a/app/controllers/sessions/qr_login_controller.rb
+++ b/app/controllers/sessions/qr_login_controller.rb
@@ -1,5 +1,7 @@
 class Sessions::QrLoginController < ApplicationController
   include IpRestrictedLogin
+  skip_before_action :authenticate_user!
+  before_action :check_login_ip_access!
 
   def create
     qr_login_session = QrLoginSession.create!
@@ -53,7 +55,7 @@ class Sessions::QrLoginController < ApplicationController
 
   private
 
-  def restrict_remote_ip
+  def check_login_ip_access!
     require_ip_whitelist!
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,8 @@
 class SessionsController < ApplicationController
   include IpRestrictedLogin
   layout false
+  skip_before_action :authenticate_user!
+  before_action :check_login_ip_access!
 
   def index
     log_out
@@ -23,7 +25,7 @@ class SessionsController < ApplicationController
 
   private
 
-  def restrict_remote_ip
+  def check_login_ip_access!
     require_ip_whitelist!
   end
 end

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -1,5 +1,5 @@
 class SystemsController < ApplicationController
-  before_action :permit_admin, only: [:edit, :update]
+  before_action :authorize_admin!, only: [:edit, :update]
   before_action :set_system
 
   def edit; end

--- a/app/controllers/tablets/sessions_controller.rb
+++ b/app/controllers/tablets/sessions_controller.rb
@@ -1,6 +1,8 @@
 class Tablets::SessionsController < TabletsController
   include IpRestrictedLogin
   layout false
+  skip_before_action :authenticate_user!
+  before_action :check_login_ip_access!
 
   def new
     log_out
@@ -8,7 +10,7 @@ class Tablets::SessionsController < TabletsController
 
   private
 
-  def restrict_remote_ip
+  def check_login_ip_access!
     require_ip_whitelist!(return_to: tablets_menu_index_path)
   end
 end

--- a/app/controllers/users/line_hooks_controller.rb
+++ b/app/controllers/users/line_hooks_controller.rb
@@ -1,6 +1,6 @@
 class Users::LineHooksController < ApplicationController
   protect_from_forgery with: :null_session
-  skip_before_action :restrict_remote_ip
+  skip_before_action :authenticate_user!
 
   def create
     events = params['events'] || []

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:edit, :update, :destroy]
   before_action :set_return_to, only: [:new, :create, :edit, :update, :destroy]
-  before_action :permit_admin, only: [:index, :new, :create, :destroy]
+  before_action :authorize_admin!, only: [:index, :new, :create, :destroy]
   before_action :permit_self, only: [:edit, :update]
 
   def index

--- a/app/controllers/work_types_controller.rb
+++ b/app/controllers/work_types_controller.rb
@@ -1,7 +1,7 @@
 class WorkTypesController < ApplicationController
   include ReturnToIndex
 
-  skip_before_action :restrict_remote_ip, only: [:icon]
+  skip_before_action :authenticate_user!, only: [:icon]
   before_action :permit_manager, except: [:icon]
   before_action :set_work_type, only: [:edit, :update, :destroy]
   keeps_index_return_to path_method: :work_types_path

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -175,6 +175,7 @@ class WorksController < ApplicationController
   end
 
   def authorize_current_term!
+    super
     to_error_path unless @work.present? && @work.term == current_term
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -175,7 +175,6 @@ class WorksController < ApplicationController
   end
 
   def authorize_current_term!
-    super
     to_error_path unless @work.present? && @work.term == current_term
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -11,7 +11,7 @@ class WorksController < ApplicationController
   before_action :permit_not_visitor, except: [:index, :show]
   before_action :permit_checkable_or_self, only: [:edit, :update, :destroy]
   before_action :permit_visitor, only: :show
-  before_action :permit_this_term, only: [:edit, :update, :destroy]
+  before_action :authorize_current_term!, only: [:edit, :update, :destroy]
 
   helper WorksHelper
   helper GmapHelper
@@ -174,7 +174,7 @@ class WorksController < ApplicationController
     to_error_path if current_user.visitor? && !@work.work_results.exists?(worker_id: current_user.worker.id)
   end
 
-  def permit_this_term
+  def authorize_current_term!
     to_error_path unless @work.present? && @work.term == current_term
   end
 


### PR DESCRIPTION
以下のリファクタリングを行う。

app/controllers/application_controller.rb は便利な共通置き場になっていますが、restrict_remote_ip という名前で実際はログイン必須チェックをしていたり、本番で StandardError を丸ごと rescue していたりします。ここは authenticate_user!、authorize_*、check_access_target!、handle_internal_error のように名前と責務を分けると、あとから読む人にもかなり優しくなります。