### PR TITLE
#901 codex:phase3 穴埋め

### DIFF
--- a/app/controllers/concerns/updatable_work.rb
+++ b/app/controllers/concerns/updatable_work.rb
@@ -11,6 +11,7 @@ module UpdatableWork
     return false unless current_user && work
 
     (current_user.checkable? || work.created_by == current_user.worker.id) &&
-      work.term == current_user.term
+      work.term == current_user.term &&
+      work.organization_id == current_user.organization_id
   end
 end

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -10,7 +10,7 @@ class ContractsController < ApplicationController
 
   def work_lands
     work_lands = []
-    Work.by_target(current_term).landable.where(work_type_id: current_organization.contract_work_type_id).find_each do |work|
+    Work.for_organization(current_organization).by_target(current_term).landable.where(work_type_id: current_organization.contract_work_type_id).find_each do |work|
       work_lands << work.work_lands
     end
     work_lands = work_lands.flatten.sort { |a, b| a.work.worked_at <=> b.work.worked_at }

--- a/app/controllers/dryings_controller.rb
+++ b/app/controllers/dryings_controller.rb
@@ -10,11 +10,11 @@ class DryingsController < ApplicationController
   def index
     @works = WorkDecorator.decorate_collection(Work.for_drying(current_term, current_organization))
     @new_drying = Drying.new(term: current_term)
-    @dryings = Drying.where(term: current_term).to_a
+    @dryings = Drying.for_organization(current_organization).where(term: current_term).to_a
   end
 
   def show
-    @home = Home.find(params[:id])
+    @home = Home.for_organization(current_organization).find(params[:id])
     @dryings = DryingDecorator.decorate_collection(Drying.by_home(current_term, @home))
     @total_dryings, @waste_totals, @shipped_totals = Drying.calc_total(@dryings, @home, current_system)
   end
@@ -25,6 +25,8 @@ class DryingsController < ApplicationController
 
   def create
     @drying = Drying.new(drying_params)
+    return to_error_path unless Home.for_organization(current_organization).exists?(id: @drying.home_id)
+
     if @drying.save
       redirect_to dryings_path
     else
@@ -69,7 +71,7 @@ class DryingsController < ApplicationController
   end
 
   def set_drying
-    @drying = Drying.find(params[:id])
+    @drying = Drying.for_organization(current_organization).find(params[:id])
   end
 
   def default_moths
@@ -89,15 +91,15 @@ class DryingsController < ApplicationController
   end
 
   def set_homes
-    @homes = Home.for_drying.includes(:holder)
+    @homes = Home.for_organization(current_organization).for_drying.includes(:holder)
   end
 
   def set_lands
-    @lands = WorkLand.by_worked_at(@drying.carried_on)
+    @lands = WorkLand.by_worked_at(@drying.carried_on, current_organization)
   end
 
   def set_work_types
-    @work_types = Work.types_by_worked_at(@drying.carried_on)
+    @work_types = Work.types_by_worked_at(@drying.carried_on, current_organization)
   end
 
   def build_drying

--- a/app/controllers/gaps/accidents_controller.rb
+++ b/app/controllers/gaps/accidents_controller.rb
@@ -39,7 +39,7 @@ class Gaps::AccidentsController < GapsController
   end
 
   def works
-    @works = WorkDecorator.decorate_collection(Work.usual(current_term).where(worked_at: params[:worked_at]))
+    @works = WorkDecorator.decorate_collection(Work.for_organization(current_organization).usual(current_term).where(worked_at: params[:worked_at]))
     @work_id = params[:id]
     respond_to { |format| format.turbo_stream }
   end
@@ -47,7 +47,7 @@ class Gaps::AccidentsController < GapsController
   def audiences
     return if params[:work_id].blank?
 
-    @workers = WorkerDecorator.decorate_collection(Work.find(params[:work_id]).workers)
+    @workers = WorkerDecorator.decorate_collection(Work.for_organization(current_organization).find(params[:work_id]).workers)
     @worker_id = params[:id]
     respond_to { |format| format.turbo_stream }
   end
@@ -55,8 +55,8 @@ class Gaps::AccidentsController < GapsController
   private
 
   def set_accident
-    @accident = Accident.find(params[:id])
-    @works = WorkDecorator.decorate_collection(Work.usual(@accident.work.term).where(worked_at: @accident.work.worked_at))
+    @accident = Accident.joins(:work).where(works: { organization_id: current_organization.id }).find(params[:id])
+    @works = WorkDecorator.decorate_collection(Work.for_organization(current_organization).usual(@accident.work.term).where(worked_at: @accident.work.worked_at))
     @workers = WorkerDecorator.decorate_collection(@accident.work.workers)
   end
 

--- a/app/controllers/gaps/cleanings_controller.rb
+++ b/app/controllers/gaps/cleanings_controller.rb
@@ -2,7 +2,7 @@ class Gaps::CleaningsController < GapsController
   before_action :set_work, only: [:edit, :update]
 
   def index
-    @works = WorkDecorator.decorate_collection(Work.by_term(current_term).where(work_kind_id: current_organization.cleaning_id))
+    @works = WorkDecorator.decorate_collection(Work.for_organization(current_organization).by_term(current_term).where(work_kind_id: current_organization.cleaning_id))
   end
 
   def edit; end
@@ -19,7 +19,7 @@ class Gaps::CleaningsController < GapsController
   private
 
   def set_work
-    @work = Work.find(params[:id]).decorate
+    @work = Work.for_organization(current_organization).find(params[:id]).decorate
     @cleaning = @work.model.cleaning || Cleaning.new(work_id: params[:id])
   end
 

--- a/app/controllers/gaps/maintenances_controller.rb
+++ b/app/controllers/gaps/maintenances_controller.rb
@@ -1,5 +1,5 @@
 class Gaps::MaintenancesController < GapsController
   def index
-    @works = WorkDecorator.decorate_collection(Work.by_term(current_term).where(work_kind_id: current_organization.maintenance_id))
+    @works = WorkDecorator.decorate_collection(Work.for_organization(current_organization).by_term(current_term).where(work_kind_id: current_organization.maintenance_id))
   end
 end

--- a/app/controllers/gaps/trainings_controller.rb
+++ b/app/controllers/gaps/trainings_controller.rb
@@ -3,7 +3,7 @@ class Gaps::TrainingsController < GapsController
 
   def index
     @works = WorkDecorator.decorate_collection(
-      Work.by_term(current_term).where(work_kind_id: current_organization.training_id).includes(:training, :workers)
+      Work.for_organization(current_organization).by_term(current_term).where(work_kind_id: current_organization.training_id).includes(:training, :workers)
       .includes(:work_kind)
     )
   end
@@ -29,7 +29,7 @@ class Gaps::TrainingsController < GapsController
   private
 
   def set_traning
-    @work = Work.find(params[:id]).decorate
+    @work = Work.for_organization(current_organization).find(params[:id]).decorate
     @training = @work&.training || Training.new
     @schedules = Schedule.for_training(@work)
   end

--- a/app/controllers/land_costs_controller.rb
+++ b/app/controllers/land_costs_controller.rb
@@ -12,7 +12,7 @@ class LandCostsController < ApplicationController
   def index
     @land_places = LandPlace.usual
     @land_place_id = (params[:land_place_id] || @land_places.first.id).to_i
-    @lands = Land.where(land_place_id: @land_place_id).by_term(current_system).usual
+    @lands = Land.for_organization(current_organization).where(land_place_id: @land_place_id).by_term(current_system).usual
     @costs = LandCost.usual(@lands, Time.zone.today)
     respond_to do |format|
       format.turbo_stream
@@ -31,7 +31,7 @@ class LandCostsController < ApplicationController
         next if land_cost[:work_type_id].blank? || land_cost[:land_id].blank? || land_cost[:activated_on].blank?
 
         if land_cost[:id].present?
-          @land_cost = LandCost.find(land_cost[:id])
+          @land_cost = LandCost.joins(:land).where(lands: { organization_id: current_organization.id }).find(land_cost[:id])
           session[:land_cost] = @land_cost.attributes unless @land_cost.update_work_type(land_cost_params(land_cost), current_system.start_date)
         else
           @land_cost = LandCost.new(land_cost_params(land_cost))
@@ -52,7 +52,7 @@ class LandCostsController < ApplicationController
 
   def map
     @target = params[:target].presence || Time.zone.today
-    @costs = LandCost.usual(Land.regionable.expiry(@target), @target).includes(land: [:owner, { manager: :holder }], work_type: [])
+    @costs = LandCost.usual(Land.for_organization(current_organization).regionable.expiry(@target), @target).includes(land: [:owner, { manager: :holder }], work_type: [])
     @work_types = WorkType.land.by_term(current_organization.get_term(@target))
   end
 
@@ -70,7 +70,7 @@ class LandCostsController < ApplicationController
   end
 
   def set_land
-    @land = Land.find(params[:land_id])
+    @land = Land.for_organization(current_organization).find(params[:land_id])
   end
 
   def set_land_cost

--- a/app/controllers/lands/cards_controller.rb
+++ b/app/controllers/lands/cards_controller.rb
@@ -4,11 +4,11 @@ class Lands::CardsController < ApplicationController
   helper GmapHelper
 
   def index
-    @costs = LandCost.usual(Land.regionable.expiry(Time.zone.today), Time.zone.today).includes(land: :owner).includes(:work_type)
+    @costs = LandCost.usual(Land.for_organization(current_organization).regionable.expiry(Time.zone.today), Time.zone.today).includes(land: :owner).includes(:work_type)
   end
 
   def show
-    @land = Land.find(params[:land_id])
+    @land = Land.for_organization(current_organization).find(params[:land_id])
     @work_lands = WorkLandDecorator.decorate_collection(WorkLand.for_cards(params[:land_id], now_system.start_date.prev_year))
   end
 end

--- a/app/controllers/lands/fees_controller.rb
+++ b/app/controllers/lands/fees_controller.rb
@@ -2,11 +2,11 @@ class Lands::FeesController < ApplicationController
   include PermitManager
 
   def index
-    @homes = Home.for_fee.landable
+    @homes = Home.for_organization(current_organization).for_fee.landable
   end
 
   def edit
-    @home = Home.find(params[:id])
+    @home = Home.for_organization(current_organization).find(params[:id])
   end
 
   def create
@@ -14,6 +14,7 @@ class Lands::FeesController < ApplicationController
   end
 
   def update
+    Home.for_organization(current_organization).find(params[:id])
     LandFee.save_all_from_params(params[:id], fee_params)
     redirect_to(lands_fees_path)
   end

--- a/app/controllers/lands/managers_controller.rb
+++ b/app/controllers/lands/managers_controller.rb
@@ -13,13 +13,14 @@ class Lands::ManagersController < ApplicationController
   end
 
   def destroy
-    LandHome.where(land_id: params[:land_id], manager_flag: true).destroy_all
+    land = Land.for_organization(current_organization).find(params[:land_id])
+    land.land_homes.where(manager_flag: true).destroy_all
   end
 
   private
 
   def set_land
-    @land = Land.find(params[:land_id])
+    @land = Land.for_organization(current_organization).find(params[:land_id])
     @manager_flag = true
     @owner_flag = false
   end

--- a/app/controllers/lands/owners_controller.rb
+++ b/app/controllers/lands/owners_controller.rb
@@ -13,13 +13,14 @@ class Lands::OwnersController < ApplicationController
   end
 
   def destroy
-    LandHome.where(land_id: params[:land_id], owner_flag: true).destroy_all
+    land = Land.for_organization(current_organization).find(params[:land_id])
+    land.land_homes.where(owner_flag: true).destroy_all
   end
 
   private
 
   def set_land
-    @land = Land.find(params[:land_id])
+    @land = Land.for_organization(current_organization).find(params[:land_id])
     @owner_flag = true
     @manager_flag = false
   end

--- a/app/controllers/owned_rices_controller.rb
+++ b/app/controllers/owned_rices_controller.rb
@@ -15,7 +15,8 @@ class OwnedRicesController < ApplicationController
   end
 
   def update
-    return to_error_path unless owned_rice_home_ids.all? { |home_id| Home.for_organization(current_organization).exists?(id: home_id) }
+    home_ids = owned_rice_home_ids.uniq
+    return to_error_path unless Home.for_organization(current_organization).where(id: home_ids).count == home_ids.size
 
     params.require(:owned_rices).each_value do |v|
       OwnedRice.regist(v[:id], v.permit(:home_id, :owned_rice_price_id, :owned_count), current_organization)

--- a/app/controllers/owned_rices_controller.rb
+++ b/app/controllers/owned_rices_controller.rb
@@ -3,20 +3,22 @@ class OwnedRicesController < ApplicationController
   before_action :set_prices, only: [:index, :edit]
 
   def index
-    @homes = Home.for_owned_rice
-    @owned_rices = OwnedRice.usual(current_term).to_a
+    @homes = Home.for_organization(current_organization).for_owned_rice
+    @owned_rices = OwnedRice.usual(current_term, current_organization).to_a
   end
 
   def edit
-    @home = Home.find(params[:id])
+    @home = Home.for_organization(current_organization).find(params[:id])
     @p_owned_prices = OwnedRicePrice.usual(previous_term).to_a
-    @p_owned_rices = OwnedRice.by_home(previous_term, params[:id]).to_a
-    @owned_rices = OwnedRice.by_home(current_term, params[:id]).to_a
+    @p_owned_rices = OwnedRice.by_home(previous_term, params[:id], current_organization).to_a
+    @owned_rices = OwnedRice.by_home(current_term, params[:id], current_organization).to_a
   end
 
   def update
+    return to_error_path unless owned_rice_home_ids.all? { |home_id| Home.for_organization(current_organization).exists?(id: home_id) }
+
     params.require(:owned_rices).each_value do |v|
-      OwnedRice.regist(v[:id], v.permit(:home_id, :owned_rice_price_id, :owned_count))
+      OwnedRice.regist(v[:id], v.permit(:home_id, :owned_rice_price_id, :owned_count), current_organization)
     end
     redirect_to owned_rices_path
   end
@@ -25,5 +27,9 @@ class OwnedRicesController < ApplicationController
 
   def set_prices
     @owned_prices = OwnedRicePrice.usual(current_term).to_a
+  end
+
+  def owned_rice_home_ids
+    params.require(:owned_rices).values.filter_map { |v| v[:home_id].presence&.to_i }
   end
 end

--- a/app/controllers/personal_informations/lands_controller.rb
+++ b/app/controllers/personal_informations/lands_controller.rb
@@ -1,10 +1,10 @@
 class PersonalInformations::LandsController < PersonalInformationsController
   def index
-    @lands = LandDecorator.decorate_collection(Land.usual.expiry.for_personal(@worker.home))
+    @lands = LandDecorator.decorate_collection(Land.for_organization(current_organization).usual.expiry.for_personal(@worker.home))
   end
 
   def show
-    @land = Land.find(params[:id]).decorate
+    @land = Land.for_organization(current_organization).find(params[:id]).decorate
     @work_lands = WorkLandDecorator.decorate_collection(WorkLand.for_cards(@land.id, now_system.start_date))
     @land_costs = LandCostDecorator.decorate_collection(LandCost.by_land(@land.id))
   end

--- a/app/controllers/personal_informations/works_controller.rb
+++ b/app/controllers/personal_informations/works_controller.rb
@@ -13,7 +13,7 @@ class PersonalInformations::WorksController < PersonalInformationsController
   end
 
   def set_work
-    @work = Work.find(params[:id]).decorate
+    @work = Work.for_organization(current_organization).find(params[:id]).decorate
   end
 
   def set_results

--- a/app/controllers/seedling_results_controller.rb
+++ b/app/controllers/seedling_results_controller.rb
@@ -23,20 +23,21 @@ class SeedlingResultsController < ApplicationController
   end
 
   def work_results
+    work = Work.for_organization(current_organization).find(params[:work_id])
     render turbo_stream: turbo_stream.replace(
       "work_results_#{params[:index]}", partial: 'work_results',
-                                        locals: { data_index: params[:index], work_results: Work.find(params[:work_id]).work_results.includes(:worker), work_result_id: 0 }
+                                        locals: { data_index: params[:index], work_results: work.work_results.includes(:worker), work_result_id: 0 }
     )
   end
 
   private
 
   def set_seedling_home
-    @seedling_home = SeedlingHome.find(params[:seedling_home_id])
+    @seedling_home = SeedlingHome.joins(:home).where(homes: { organization_id: current_organization.id }).find(params[:seedling_home_id])
   end
 
   def set_works
-    @works = Work.by_work_kind_type(current_term, current_organization.rice_planting_id, @seedling_home)
+    @works = Work.by_work_kind_type(current_term, current_organization.rice_planting_id, @seedling_home, current_organization)
   end
 
   def set_seedling_results

--- a/app/controllers/tasks/works_controller.rb
+++ b/app/controllers/tasks/works_controller.rb
@@ -3,7 +3,7 @@ class Tasks::WorksController < TasksController
   before_action :set_work, only: [:update, :destroy]
 
   def index
-    @works = WorkDecorator.decorate_collection(Work.for_task(@task))
+    @works = WorkDecorator.decorate_collection(Work.for_organization(current_organization).for_task(@task))
   end
 
   def update
@@ -48,6 +48,6 @@ class Tasks::WorksController < TasksController
   private
 
   def set_work
-    @work = Work.find(params[:id])
+    @work = Work.for_organization(current_organization).find(params[:id])
   end
 end

--- a/app/controllers/total_chemicals_controller.rb
+++ b/app/controllers/total_chemicals_controller.rb
@@ -4,6 +4,6 @@ class TotalChemicalsController < ApplicationController
   def index
     work_kind = current_organization.rice_planting
     @chemical_types = work_kind.chemical_types
-    @works = Work.usual(current_term).where(work_kind_id: work_kind)
+    @works = Work.for_organization(current_organization).usual(current_term).where(work_kind_id: work_kind)
   end
 end

--- a/app/controllers/total_owned_rices_controller.rb
+++ b/app/controllers/total_owned_rices_controller.rb
@@ -2,7 +2,7 @@ class TotalOwnedRicesController < ApplicationController
   include PermitManager
 
   def index
-    @owned_rices = OwnedRice.for_finance(current_term)
+    @owned_rices = OwnedRice.for_finance(current_term, current_organization)
     respond_to do |format|
       format.html do
         @home_totals = calc_totals(@owned_rices)
@@ -36,8 +36,9 @@ class TotalOwnedRicesController < ApplicationController
   def save_relatives(totals)
     results = {}
     totals.each do |k, v|
-      if v[:owned_count] > Home.find(k).owned_rice_limit(current_term)
-        results[k] = v[:owned_count] - Home.find(k).owned_rice_limit(current_term)
+      home = Home.for_organization(current_organization).find(k)
+      if v[:owned_count] > home.owned_rice_limit(current_term)
+        results[k] = v[:owned_count] - home.owned_rice_limit(current_term)
         totals[k][:owned_price] += results[k] * current_system.relative_price
       end
     end

--- a/app/controllers/work_seedlings_controller.rb
+++ b/app/controllers/work_seedlings_controller.rb
@@ -3,7 +3,7 @@ class WorkSeedlingsController < ApplicationController
 
   def index
     @work_types = WorkType.land
-    @work_seedlings, @work_areas = calc_seedlings(Work.where(work_kind_id: current_organization.rice_planting_id).by_term(@term))
+    @work_seedlings, @work_areas = calc_seedlings(Work.for_organization(current_organization).where(work_kind_id: current_organization.rice_planting_id).by_term(@term))
 
     respond_to do |format|
       format.html do

--- a/app/controllers/work_verifications_controller.rb
+++ b/app/controllers/work_verifications_controller.rb
@@ -36,7 +36,7 @@ class WorkVerificationsController < ApplicationController
   end
 
   def set_work
-    @work = Work.where(fixed_at: nil, term: current_term).find(params[:work_id])
+    @work = Work.for_organization(current_organization).where(fixed_at: nil, term: current_term).find(params[:work_id])
     to_error_path if @work.nil?
   end
 end

--- a/app/controllers/work_verifications_controller.rb
+++ b/app/controllers/work_verifications_controller.rb
@@ -37,6 +37,5 @@ class WorkVerificationsController < ApplicationController
 
   def set_work
     @work = Work.for_organization(current_organization).where(fixed_at: nil, term: current_term).find(params[:work_id])
-    to_error_path if @work.nil?
   end
 end

--- a/app/controllers/works/print_controller.rb
+++ b/app/controllers/works/print_controller.rb
@@ -19,7 +19,7 @@ class Works::PrintController < ApplicationController
   private
 
   def set_work
-    @work = Work.find(params[:work_id]).decorate
+    @work = Work.for_organization(current_organization).find(params[:work_id]).decorate
   end
 
   def permit_checkable_or_self

--- a/app/models/drying.rb
+++ b/app/models/drying.rb
@@ -38,6 +38,12 @@ class Drying < ApplicationRecord
   accepts_nested_attributes_for :drying_lands
   accepts_nested_attributes_for :adjustment
 
+  validate :homes_belong_to_same_organization
+
+  scope :for_organization, lambda { |organization|
+    joins(:home).where(homes: { organization_id: organization.is_a?(Organization) ? organization.id : organization })
+  }
+
   scope :by_home, lambda { |term, home|
     left_joins(:adjustment)
       .where(["dryings.term = ? AND (dryings.home_id = ? OR adjustments.home_id = ?)", term, home.id, home.id])
@@ -82,7 +88,7 @@ class Drying < ApplicationRecord
 
   def delete_child
     if country?
-      adjustment.destroy
+      adjustment&.destroy
     else
       drying_moths.destroy_all
     end
@@ -162,5 +168,14 @@ class Drying < ApplicationRecord
 
   def drying_type_name
     I18n.t("activerecord.enums.drying.drying_type_ids.#{drying_type_id}")
+  end
+
+  private
+
+  def homes_belong_to_same_organization
+    return if home.blank?
+    return if adjustment.blank? || adjustment.home.blank? || adjustment.home.organization_id == home.organization_id
+
+    errors.add(:base, "調整先の世帯は乾燥担当世帯と同じ組織にしてください。")
   end
 end

--- a/app/models/land_home.rb
+++ b/app/models/land_home.rb
@@ -16,4 +16,14 @@
 class LandHome < ApplicationRecord
   belongs_to :home, -> { with_deleted }
   belongs_to :land
+
+  validate :home_belongs_to_same_organization
+
+  private
+
+  def home_belongs_to_same_organization
+    return if land.blank? || home.blank? || land.organization_id == home.organization_id
+
+    errors.add(:home_id, "は土地と同じ組織の世帯を選択してください。")
+  end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -53,7 +53,7 @@ class Organization < ApplicationRecord
   has_many :systems, dependent: :destroy
 
   def self.term(organization = nil)
-    organization&.term || Organization.first.term
+    organization&.term || 0
   end
 
   def get_system(date)

--- a/app/models/owned_rice.rb
+++ b/app/models/owned_rice.rb
@@ -20,29 +20,36 @@ class OwnedRice < ApplicationRecord
 
   OWNED_RICE_COUNT = 2 # 10a当たりの保有米数
 
-  scope :usual, lambda { |term|
-    joins(:owned_rice_price)
+  scope :usual, lambda { |term, organization = nil|
+    base = joins(:owned_rice_price)
       .where(owned_rice_prices: { term: term })
+    organization ? base.joins(:home).where(homes: { organization_id: organization.is_a?(Organization) ? organization.id : organization }) : base
   }
 
-  scope :by_home, lambda { |term, home_id|
-    joins(:owned_rice_price)
+  scope :by_home, lambda { |term, home_id, organization = nil|
+    base = joins(:owned_rice_price)
       .where(["owned_rice_prices.term = ? AND owned_rices.home_id = ?", term, home_id])
       .order("owned_rice_prices.display_order, owned_rice_prices.id")
+    organization ? base.joins(:home).where(homes: { organization_id: organization.is_a?(Organization) ? organization.id : organization }) : base
   }
 
   scope :available, -> { where("owned_rices.owned_count > 0") }
 
-  scope :for_finance, lambda { |term|
-    joins(:owned_rice_price)
+  scope :for_finance, lambda { |term, organization = nil|
+    base = joins(:owned_rice_price)
       .joins(:home)
       .where(owned_rice_prices: { term: term })
       .where("owned_rices.owned_count > 0")
       .order("homes.finance_order, homes.id, owned_rice_prices.display_order, owned_rice_prices.id")
+    organization ? base.where(homes: { organization_id: organization.is_a?(Organization) ? organization.id : organization }) : base
   }
 
-  def self.regist(id, params)
-    owned_rice = OwnedRice.find_by(id: id) if id
+  def self.regist(id, params, organization = nil)
+    owned_rice = if id && organization
+                   OwnedRice.joins(:home).where(homes: { organization_id: organization.is_a?(Organization) ? organization.id : organization }).find_by(id: id)
+                 elsif id
+                   OwnedRice.find_by(id: id)
+                 end
     if owned_rice
       owned_rice.update(params)
     else

--- a/app/models/whole_crop_land.rb
+++ b/app/models/whole_crop_land.rb
@@ -19,6 +19,8 @@ class WholeCropLand < ApplicationRecord
   belongs_to :work_whole_crop
   belongs_to :work_land
 
+  validate :work_land_belongs_to_same_organization
+
   has_many :wcs_rolls, -> { order("whole_crop_rolls.display_order") }, class_name: "WholeCropRoll", dependent: :destroy
 
   scope :for_sales, lambda { |term|
@@ -29,7 +31,7 @@ class WholeCropLand < ApplicationRecord
     params.each do |param|
       wcs_land = nil
       if param[:id].present?
-        wcs_land = WholeCropLand.find(param[:id])
+        wcs_land = whole_crop.wcs_lands.find(param[:id])
         wcs_land.update(wcs_lands_param(whole_crop, param))
       else
         wcs_land = WholeCropLand.create(wcs_lands_param(whole_crop, param))
@@ -44,5 +46,14 @@ class WholeCropLand < ApplicationRecord
 
   def price
     (rolls * work_whole_crop.roll_price * (100 + work_whole_crop.tax_rate) / 100).floor(0)
+  end
+
+  private
+
+  def work_land_belongs_to_same_organization
+    return if work_whole_crop&.work.blank? || work_land&.work.blank?
+    return if work_whole_crop.work.organization_id == work_land.work.organization_id
+
+    errors.add(:work_land_id, "はWCS作業と同じ組織の作業地を選択してください。")
   end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -87,7 +87,7 @@ class Work < ApplicationRecord
   scope :usual, ->(term) { where(term: term).includes(:work_type, :work_kind).order(worked_at: :DESC, start_at: :DESC, id: :DESC) }
   scope :by_term, ->(term) { where(term: term).order(worked_at: :ASC, start_at: :ASC, id: :ASC) }
   scope :by_creator, ->(worker) { where(["works.created_by IS NULL OR works.created_by <> ?", worker.id]) }
-  scope :by_work_kind_type, lambda { |term, work_kind_id, seedling_home|
+  scope :by_work_kind_type, lambda { |term, work_kind_id, seedling_home, organization = nil|
     works = arel_table
     work_lands = WorkLand.arel_table
     land_costs = LandCost.arel_table.alias("lc1")
@@ -113,13 +113,14 @@ class Work < ApplicationRecord
           .and(latest_land_cost_query.exists)
       )
 
-    joins(:work_lands)
+    base = joins(:work_lands)
       .where(term: term, work_kind_id: work_kind_id)
       .where(works: { worked_at: seedling_home.sowed_on.. })
       .where(land_cost_query.exists)
       .select(:id, :worked_at)
       .distinct
       .order(worked_at: :ASC, id: :ASC)
+    organization ? base.for_organization(organization) : base
   }
   scope :enough_check, lambda { |worker|
     work_verifications = WorkVerification.arel_table
@@ -265,6 +266,7 @@ SQL
   scope :for_drying, lambda { |term, organization|
     select("worked_at")
       .where(term: term, work_kind_id: organization.harvesting_work_kind_id)
+      .for_organization(organization)
       .distinct
       .order(:worked_at)
   }
@@ -359,6 +361,7 @@ SQL
   def self.for_verifications(user)
     Work.includes(:work_results, :creator)
       .includes(:machine_results, :work_lands, :work_type, :work_chemicals, :checkers)
+      .for_organization(user.organization_id)
       .no_fixed(user.term).by_creator(user.worker).enough_check(user.worker).not_printed
   end
 
@@ -437,9 +440,11 @@ SQL
     work_type&.land_flag ? TotalCostType::WORKWORKER : TotalCostType::WORKINDIRECT
   end
 
-  def self.types_by_worked_at(worked_at)
+  def self.types_by_worked_at(worked_at, organization = nil)
     wts = []
-    Work.where(worked_at: worked_at).find_each do |work|
+    base = Work.where(worked_at: worked_at)
+    base = base.for_organization(organization) if organization
+    base.find_each do |work|
       work.lands.each do |land|
         wts << land.cost(worked_at)&.work_type
       end

--- a/app/models/work_land.rb
+++ b/app/models/work_land.rb
@@ -71,9 +71,11 @@ class WorkLand < ApplicationRecord
     local_cost + (work.sum_workers_amount - work.work_lands.sum(&:interim_cost))
   end
 
-  def self.by_worked_at(worked_at)
+  def self.by_worked_at(worked_at, organization = nil)
     lands = []
-    Work.where(worked_at: worked_at).find_each do |work|
+    base = Work.where(worked_at: worked_at)
+    base = base.for_organization(organization) if organization
+    base.find_each do |work|
       lands << work.lands.to_a
     end
     lands.flatten.uniq

--- a/test/controllers/dryings_controller_test.rb
+++ b/test/controllers/dryings_controller_test.rb
@@ -38,9 +38,30 @@ class DryingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "別組織の乾燥照会" do
+    get drying_path(id: homes(:home_other_org).id)
+
+    assert_response :not_found
+  end
+
   test "乾燥編集" do
     get edit_drying_path(id: dryings(:drying1).id)
     assert_response :success
+  end
+
+  test "別組織の乾燥編集" do
+    drying = Drying.create!(
+      term: systems(:s2015).term,
+      work_type_id: work_types(:work_type_koshi).id,
+      home_id: homes(:home_other_org).id,
+      drying_type_id: :country,
+      carried_on: Date.new(2015, 8, 31),
+      shipped_on: Date.new(2015, 9, 1)
+    )
+
+    get edit_drying_path(id: drying.id)
+
+    assert_response :not_found
   end
 
   test "乾燥登録(カントリー)" do
@@ -202,5 +223,18 @@ class DryingsControllerTest < ActionDispatch::IntegrationTest
     assert_equal drying.term, copy_drying.term
     assert_equal drying.carried_on, copy_drying.carried_on
     assert_equal drying.home_id, copy_drying.home_id
+  end
+
+  test "別組織の世帯では乾燥作成できない" do
+    new_drying = {
+      term: systems(:s2015).term,
+      carried_on: Date.new(2015, 8, 31),
+      home_id: homes(:home_other_org).id
+    }
+
+    assert_no_difference('Drying.count') do
+      post dryings_path, params: { drying: new_drying }
+    end
+    assert_response :error
   end
 end

--- a/test/controllers/personal_informations/lands_controller_test.rb
+++ b/test/controllers/personal_informations/lands_controller_test.rb
@@ -16,4 +16,10 @@ class PersonalInformations::LandsControllerTest < ActionDispatch::IntegrationTes
       assert_response :success
     end
   end
+
+  test "個人情報で別組織の土地は参照できない" do
+    get personal_information_land_path(personal_information_token: @user.token, id: lands(:land_other_org).id)
+
+    assert_response :not_found
+  end
 end

--- a/test/controllers/personal_informations/works_controller_test.rb
+++ b/test/controllers/personal_informations/works_controller_test.rb
@@ -10,4 +10,10 @@ class PersonalInformations::WorksControllerTest < ActionDispatch::IntegrationTes
     get personal_information_work_path(personal_information_token: @user.token, id: work.id)
     assert_response :success
   end
+
+  test "個人情報で別組織の日報は参照できない" do
+    get personal_information_work_path(personal_information_token: @user.token, id: works(:work_other_org).id)
+
+    assert_response :not_found
+  end
 end

--- a/test/controllers/work_verifications_controller_test.rb
+++ b/test/controllers/work_verifications_controller_test.rb
@@ -41,6 +41,13 @@ class WorkVerificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @user.worker.id, verification.worker_id
   end
 
+  test "別組織の日報は検証できない" do
+    assert_no_difference('WorkVerification.count') do
+      patch work_verification_path(work_id: works(:work_other_org).id)
+    end
+    assert_response :not_found
+  end
+
   test "日報検証(取消)" do
     work = works(:work_verified)
     assert_difference('WorkVerification.count', -1) do
@@ -49,5 +56,12 @@ class WorkVerificationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_nil WorkVerification.find_by(work_id: work.id, worker_id: @user.worker.id)
+  end
+
+  test "別組織の日報は検証取消できない" do
+    assert_no_difference('WorkVerification.count') do
+      delete work_verification_path(work_id: works(:work_other_org).id)
+    end
+    assert_response :not_found
   end
 end

--- a/test/controllers/works/print_controller_test.rb
+++ b/test/controllers/works/print_controller_test.rb
@@ -18,6 +18,16 @@ class Works::PrintControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil work.printed_at
   end
 
+  test "別組織の日報は印刷できない" do
+    work = works(:work_other_org)
+
+    post work_print_index_path(work_id: work.id)
+
+    assert_response :not_found
+    assert_nil work.reload.printed_at
+    assert_nil work.printed_by
+  end
+
   test "印刷取消" do
     work = Work.find(works(:works5).id)
 
@@ -29,5 +39,13 @@ class Works::PrintControllerTest < ActionDispatch::IntegrationTest
     work.reload
     assert_nil work.printed_at
     assert_nil work.printed_by
+  end
+
+  test "別組織の日報は印刷取消できない" do
+    work = works(:work_other_org)
+
+    delete work_print_path(work_id: work.id, id: 0)
+
+    assert_response :not_found
   end
 end


### PR DESCRIPTION
- Work / Land / Home / Drying などの直接 find を、可能な範囲で current_organization スコープ経由に変更
- 日報検証、日報印刷、個人情報の日報・土地参照で、別組織 ID を指定しても取得できないように修正
- 乾燥データは home.organization_id 経由で Drying.for_organization を追加し、一覧・照会・編集・作成・関連土地/作業分類取得を組織スコープ化
- 受託、育苗、GAP事故/清掃/訓練/保守、薬剤集計、土地原価、土地カード、土地所有者/管理者、土地料金、タスク日報紐付けを組織スコープ化
- OwnedRice に組織スコープ対応を追加し、保有米一覧・編集・集計・更新時に別組織世帯へ触れないように修正
- LandHome に「土地と世帯が同じ組織であること」のバリデーションを追加
- Drying に「乾燥担当世帯と調整先世帯が同じ組織であること」のバリデーションを追加
- WholeCropLand を親 WorkWholeCrop 経由で取得するようにし、WCS作業と作業地の組織不一致をバリデーション
- UpdatableWork#updatable_work? に organization_id 一致条件を追加
- Organization.term(nil) が Organization.first にフォールバックしないように変更し、単一組織前提を除去
- 別組織アクセス拒否の controller テストを追加
  - 日報検証
  - 日報印刷
  - 個人情報の日報参照
  - 個人情報の土地参照
  - 乾燥照会/編集/作成