### PR TITLE
#1019 Chrome対応

### DIFF
--- a/app/controllers/personal_informations_controller.rb
+++ b/app/controllers/personal_informations_controller.rb
@@ -41,7 +41,7 @@ class PersonalInformationsController < ApplicationController
           purpose: "any maskable"
         }
       ]
-    }
+    }, content_type: "application/manifest+json"
   end
 
   protected

--- a/app/controllers/personal_informations_controller.rb
+++ b/app/controllers/personal_informations_controller.rb
@@ -15,6 +15,35 @@ class PersonalInformationsController < ApplicationController
     Rails.application.config.access_logger.info "SP-#{@worker.name}" unless request.referer
   end
 
+  def manifest
+    personal_url = personal_information_path(token: params[:token])
+
+    render json: {
+      name: "作業日報管理",
+      short_name: "作業日報",
+      id: personal_url,
+      start_url: personal_url,
+      scope: personal_url,
+      display: "standalone",
+      theme_color: "#198754",
+      background_color: "#ffffff",
+      icons: [
+        {
+          src: view_context.asset_path("/images/icons/farm2-192.png"),
+          sizes: "192x192",
+          type: "image/png",
+          purpose: "any maskable"
+        },
+        {
+          src: view_context.asset_path("/images/icons/farm2-512.png"),
+          sizes: "512x512",
+          type: "image/png",
+          purpose: "any maskable"
+        }
+      ]
+    }
+  end
+
   protected
 
   def set_worker

--- a/app/views/layouts/sm.html.erb
+++ b/app/views/layouts/sm.html.erb
@@ -25,7 +25,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="<%= asset_path('/images/icons/farm2-32.png') %>">
   <link rel="icon" type="image/png" sizes="16x16" href="<%= asset_path('/images/icons/farm2-16.png') %>">
   <link rel="apple-touch-icon" href="<%= asset_path('/images/icons/farm2-180.png') %>">
-  <link rel="manifest" href="<%= manifest_personal_information_path(token: token, format: :json) %>">
+  <link rel="manifest" href="<%= manifest_personal_information_path(token: token) %>">
 </head>
 <body style="padding-top:64px;">
 <main class="container-fluid">

--- a/app/views/layouts/sm.html.erb
+++ b/app/views/layouts/sm.html.erb
@@ -1,3 +1,4 @@
+<% token = params[:token] || params[:personal_information_token] %>
 <!DOCTYPE html>
 <html lang="ja" data-bs-theme="<%= current_user&.theme || 'light' %>">
 <head>
@@ -24,9 +25,8 @@
   <link rel="icon" type="image/png" sizes="32x32" href="<%= asset_path('/images/icons/farm2-32.png') %>">
   <link rel="icon" type="image/png" sizes="16x16" href="<%= asset_path('/images/icons/farm2-16.png') %>">
   <link rel="apple-touch-icon" href="<%= asset_path('/images/icons/farm2-180.png') %>">
-  <link rel="manifest" href="<%= asset_path('/manifest.json') %>">
+  <link rel="manifest" href="<%= manifest_personal_information_path(token: token, format: :json) %>">
 </head>
-<% token = params[:token] || params[:personal_information_token] %>
 <body style="padding-top:64px;">
 <main class="container-fluid">
 <% unless params[:simple] %>

--- a/config/routes/all_routes.rb
+++ b/config/routes/all_routes.rb
@@ -179,7 +179,8 @@ resources :statistics, only: [:index] do
 end
 resources :fixes, param: "fixed_at", except: [:edit, :update]
 resources :personal_informations, param: "token", only: [:show] do
-  get "manifest.json", to: "personal_informations#manifest", on: :member, as: :manifest
+  get "manifest(.:format)", to: "personal_informations#manifest", on: :member, as: :manifest,
+                             defaults: { format: :json }
   resources :works, controller: "personal_informations/works", only: [:show]
   resources :lands, controller: "personal_informations/lands", only: [:index, :show]
   resources :machines, controller: "personal_informations/machines", only: [:index]

--- a/config/routes/all_routes.rb
+++ b/config/routes/all_routes.rb
@@ -179,6 +179,7 @@ resources :statistics, only: [:index] do
 end
 resources :fixes, param: "fixed_at", except: [:edit, :update]
 resources :personal_informations, param: "token", only: [:show] do
+  get "manifest.json", to: "personal_informations#manifest", on: :member, as: :manifest
   resources :works, controller: "personal_informations/works", only: [:show]
   resources :lands, controller: "personal_informations/lands", only: [:index, :show]
   resources :machines, controller: "personal_informations/machines", only: [:index]

--- a/test/controllers/personal_informations_controller_test.rb
+++ b/test/controllers/personal_informations_controller_test.rb
@@ -14,7 +14,7 @@ class PersonalInformationsControllerTest < ActionDispatch::IntegrationTest
     get manifest_personal_information_path(token: @user.token, format: :json)
 
     assert_response :success
-    assert_equal "application/json; charset=utf-8", response.content_type
+    assert_equal "application/manifest+json; charset=utf-8", response.content_type
 
     manifest = JSON.parse(response.body)
     assert_equal personal_information_path(token: @user.token), manifest["start_url"]

--- a/test/controllers/personal_informations_controller_test.rb
+++ b/test/controllers/personal_informations_controller_test.rb
@@ -14,7 +14,7 @@ class PersonalInformationsControllerTest < ActionDispatch::IntegrationTest
     get manifest_personal_information_path(token: @user.token, format: :json)
 
     assert_response :success
-    assert_equal "application/json; charset=utf-8", response.content_type
+    assert_equal "application/json", response.media_type
 
     manifest = JSON.parse(response.body)
     assert_equal personal_information_path(token: @user.token), manifest["start_url"]

--- a/test/controllers/personal_informations_controller_test.rb
+++ b/test/controllers/personal_informations_controller_test.rb
@@ -11,7 +11,7 @@ class PersonalInformationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "個人情報のmanifest" do
-    get manifest_personal_information_path(token: @user.token, format: :json)
+    get manifest_personal_information_path(token: @user.token)
 
     assert_response :success
     assert_equal "application/manifest+json", response.media_type

--- a/test/controllers/personal_informations_controller_test.rb
+++ b/test/controllers/personal_informations_controller_test.rb
@@ -9,4 +9,17 @@ class PersonalInformationsControllerTest < ActionDispatch::IntegrationTest
     get personal_information_path(token: @user.token)
     assert_response :success
   end
+
+  test "個人情報のmanifest" do
+    get manifest_personal_information_path(token: @user.token, format: :json)
+
+    assert_response :success
+    assert_equal "application/json; charset=utf-8", response.content_type
+
+    manifest = JSON.parse(response.body)
+    assert_equal personal_information_path(token: @user.token), manifest["start_url"]
+    assert_equal personal_information_path(token: @user.token), manifest["scope"]
+    assert_equal "standalone", manifest["display"]
+    assert_equal ["/images/icons/farm2-192.png", "/images/icons/farm2-512.png"], manifest["icons"].map { |icon| icon["src"] }
+  end
 end


### PR DESCRIPTION
スマホ画面(/personal_informations/:token)を表示し、ホーム画面へショートカットを作成した場合、Firefoxだとアイコンが表示されるが、ChromeではChromeのアイコンになってしまい、アプリケーションのアイコンが表示されない。