### PR TITLE
#901 phase.5

### DIFF
--- a/app/controllers/chemical_costs_controller.rb
+++ b/app/controllers/chemical_costs_controller.rb
@@ -5,7 +5,7 @@ class ChemicalCostsController < ApplicationController
   before_action :destroy_chemical_work_type, only: [:create]
 
   def index
-    @chemical_terms = ChemicalTerm.land.usual(current_term)
+    @chemical_terms = ChemicalTerm.land.usual(current_term, current_organization)
     @chemical_work_types = ChemicalWorkType.by_chemical_terms(@chemical_terms).includes(:chemical_term, :work_type)
   end
 
@@ -59,17 +59,19 @@ class ChemicalCostsController < ApplicationController
   end
 
   def set_chemical_work_type
-    @chemical_work_type = ChemicalWorkType.find(params[:id])
+    @chemical_work_type = ChemicalWorkType.joins(:chemical_term).where(chemical_terms: { organization_id: current_organization.id }).find(params[:id])
   end
 
   def destroy_chemical_work_type
-    ChemicalWorkType.where(
+    ChemicalWorkType.joins(:chemical_term).where(chemical_terms: { organization_id: current_organization.id }).where(
       chemical_term_id: chemical_work_type_params[:chemical_term_id],
       work_type_id: chemical_work_type_params[:work_type_id]
     ).destroy_all
   end
 
   def chemical_work_type_params
-    params.expect(chemical_work_type: [:chemical_term_id, :work_type_id, :quantity])
+    permitted = params.expect(chemical_work_type: [:chemical_term_id, :work_type_id, :quantity])
+    permitted[:chemical_term_id] = ChemicalTerm.for_organization(current_organization).find(permitted[:chemical_term_id]).id
+    permitted
   end
 end

--- a/app/controllers/chemicals/annuals_controller.rb
+++ b/app/controllers/chemicals/annuals_controller.rb
@@ -4,8 +4,8 @@ class Chemicals::AnnualsController < ApplicationController
 
   def create
     ActiveRecord::Base.transaction do
-      ChemicalTerm.annual_update(previous_term, current_term)
-      ChemicalWorkType.annual_update(previous_term, current_term)
+      ChemicalTerm.annual_update(previous_term, current_term, current_organization)
+      ChemicalWorkType.annual_update(previous_term, current_term, current_organization)
     end
     redirect_to chemicals_path
   end

--- a/app/controllers/chemicals/inventories_controller.rb
+++ b/app/controllers/chemicals/inventories_controller.rb
@@ -3,11 +3,11 @@ class Chemicals::InventoriesController < ApplicationController
   before_action :set_inventory, only: [:edit, :update, :destroy]
 
   def index
-    @inventories = ChemicalInventory.inventories
+    @inventories = ChemicalInventory.for_organization(current_organization).inventories
   end
 
   def new
-    @inventory = ChemicalInventory.new
+    @inventory = ChemicalInventory.new(organization: current_organization)
   end
 
   def edit
@@ -39,7 +39,7 @@ class Chemicals::InventoriesController < ApplicationController
   private
 
   def set_inventory
-    @inventory = ChemicalInventory.find(params[:id])
+    @inventory = ChemicalInventory.for_organization(current_organization).find(params[:id])
     to_error_path unless @inventory.inventory?
   end
 
@@ -51,6 +51,6 @@ class Chemicals::InventoriesController < ApplicationController
         :checked_on,
         stocks_attributes: [:inventory, :chemical_id, :_destroy, :id]
       )
-      .merge(chemical_adjust_type_id: :inventory)
+      .merge(chemical_adjust_type_id: :inventory, organization_id: current_organization.id)
   end
 end

--- a/app/controllers/chemicals/stocks_controller.rb
+++ b/app/controllers/chemicals/stocks_controller.rb
@@ -7,19 +7,19 @@ class Chemicals::StocksController < ApplicationController
   def index; end
 
   def load
-    @chemicals = ChemicalTerm.by_type(params[:term], params[:chemical_type_id])
+    @chemicals = ChemicalTerm.by_type(params[:term], params[:chemical_type_id], current_organization)
     render action: :load, layout: false
   end
 
   def search
     ChemicalStock.refresh(current_organization.id, @chemical_term.chemical_id)
-    @stocks = ChemicalStock.usual(@chemical_term.chemical_id).where(stock_on: @target_system.start_date..@target_system.end_date)
+    @stocks = ChemicalStock.usual(@chemical_term.chemical_id, current_organization).where(stock_on: @target_system.start_date..@target_system.end_date)
     @stocks = ChemicalStockDecorator.decorate_collection(@stocks)
     render action: :search, layout: false
   end
 
   def new
-    @stock = ChemicalStock.new
+    @stock = ChemicalStock.new(organization: current_organization)
     render :form, layout: false
   end
 
@@ -60,15 +60,15 @@ class Chemicals::StocksController < ApplicationController
           :stored,
           :shipping
         ])
-      .merge(chemical_id: @chemical_term.chemical_id)
+      .merge(chemical_id: @chemical_term.chemical_id, organization_id: current_organization.id)
   end
 
   def set_chemical_term
-    @chemical_term = ChemicalTerm.find(params[:chemical_id])
+    @chemical_term = ChemicalTerm.for_organization(current_organization).find(params[:chemical_id])
     @target_system = System.find_by(term: @chemical_term.term, organization_id: current_organization.id)
   end
 
   def set_stock
-    @stock = ChemicalStock.find(params[:id])
+    @stock = ChemicalStock.for_organization(current_organization).find(params[:id])
   end
 end

--- a/app/controllers/chemicals/stores_controller.rb
+++ b/app/controllers/chemicals/stores_controller.rb
@@ -3,11 +3,11 @@ class Chemicals::StoresController < ApplicationController
   before_action :set_inventory, only: [:edit, :update, :destroy]
 
   def index
-    @inventories = ChemicalInventory.stores
+    @inventories = ChemicalInventory.for_organization(current_organization).stores
   end
 
   def new
-    @inventory = ChemicalInventory.new
+    @inventory = ChemicalInventory.new(organization: current_organization)
   end
 
   def edit
@@ -39,7 +39,7 @@ class Chemicals::StoresController < ApplicationController
   private
 
   def set_inventory
-    @inventory = ChemicalInventory.find(params[:id])
+    @inventory = ChemicalInventory.for_organization(current_organization).find(params[:id])
   end
 
   def inventory_params
@@ -50,6 +50,6 @@ class Chemicals::StoresController < ApplicationController
         :checked_on,
         stocks_attributes: [:stored_stock, :chemical_id, :_destroy, :id]
       )
-      .merge(chemical_adjust_type_id: :stored)
+      .merge(chemical_adjust_type_id: :stored, organization_id: current_organization.id)
   end
 end

--- a/app/controllers/chemicals_controller.rb
+++ b/app/controllers/chemicals_controller.rb
@@ -7,11 +7,11 @@ class ChemicalsController < ApplicationController
   keeps_index_return_to path_method: :chemicals_path
 
   def index
-    @chemicals = ChemicalDecorator.decorate_collection(Chemical.list.page(params[:page]))
+    @chemicals = ChemicalDecorator.decorate_collection(Chemical.list(current_organization).page(params[:page]))
   end
 
   def new
-    @chemical = Chemical.new
+    @chemical = Chemical.new(organization: current_organization)
   end
 
   def edit; end
@@ -41,7 +41,7 @@ class ChemicalsController < ApplicationController
   private
 
   def set_chemical
-    @chemical = Chemical.kept.find(params[:id])
+    @chemical = Chemical.kept.for_organization(current_organization).find(params[:id])
     @chemical.term = current_term
   end
 
@@ -71,6 +71,6 @@ class ChemicalsController < ApplicationController
         :stock_unit,
         :url
       ])
-      .merge(term: current_term)
+      .merge(term: current_term, organization_id: current_organization.id)
   end
 end

--- a/app/controllers/gaps/chemicals_controller.rb
+++ b/app/controllers/gaps/chemicals_controller.rb
@@ -2,11 +2,11 @@ class Gaps::ChemicalsController < GapsController
   def index
     return unless params[:chemical_type_id]
 
-    @chemicals = ChemicalTerm.by_type(current_term, params[:chemical_type_id])
+    @chemicals = ChemicalTerm.by_type(current_term, params[:chemical_type_id], current_organization)
     @stocks = {}
     @chemicals.each do |chemical|
       ChemicalStock.refresh(current_organization.id, chemical.id)
-      stocks = ChemicalStock.usual(chemical.id).where(stock_on: current_system.start_date..current_system.end_date)
+      stocks = ChemicalStock.usual(chemical.id, current_organization).where(stock_on: current_system.start_date..current_system.end_date)
       @stocks[chemical.id] = ChemicalStockDecorator.decorate_collection(stocks) unless stocks.empty?
     end
   end

--- a/app/models/chemical.rb
+++ b/app/models/chemical.rb
@@ -93,10 +93,13 @@ class Chemical < ApplicationRecord
   }
 
   scope :for_stock, lambda { |term, organization = nil|
+    chemical_terms = ChemicalTerm.where(term: term)
+    chemical_terms = chemical_terms.for_organization(organization) if organization
+
     joins(:chemical_type)
       .with_deleted
       .then { |base| organization ? base.for_organization(organization) : base }
-      .where(chemicals: { id: ChemicalTerm.usual(term, organization).select("chemical_id") })
+      .where(chemicals: { id: chemical_terms.select(:chemical_id) })
       .order(Arel.sql("chemical_types.display_order, chemical_types.id, chemicals.phonetic, chemicals.display_order, chemicals.id"))
   }
 

--- a/app/models/chemical.rb
+++ b/app/models/chemical.rb
@@ -19,10 +19,16 @@
 #  updated_at                 :datetime
 #  base_unit_id(基本単位)     :integer          default(0), not null
 #  chemical_type_id(薬剤種別) :integer          not null
+#  organization_id(組織)      :bigint           not null
 #
 # Indexes
 #
-#  index_chemicals_on_deleted_at  (deleted_at)
+#  index_chemicals_on_deleted_at       (deleted_at)
+#  index_chemicals_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
 #
 
 class Chemical < ApplicationRecord
@@ -35,6 +41,7 @@ class Chemical < ApplicationRecord
 
   after_save :save_term
 
+  belongs_to :organization
   belongs_to :chemical_type
   belongs_to_active_hash :base_unit
   has_many :chemical_terms, dependent: :destroy
@@ -53,11 +60,14 @@ class Chemical < ApplicationRecord
   scope :with_deleted, -> { with_discarded }
   scope :only_deleted, -> { with_discarded.discarded }
 
+  scope :for_organization, ->(organization) { where(organization_id: organization.is_a?(Organization) ? organization.id : organization) }
+
   scope :usual, lambda { |work|
     kept.joins(:chemical_type)
-      .where(<<-WHERE, work.term, ChemicalWorkType.by_work(work).map(&:chemical).map(&:id), work.work_kind.chemical_kinds.pluck(:chemical_type_id), work.chemicals.pluck(:chemical_id))
+      .for_organization(work.organization_id)
+      .where(<<-WHERE, work.term, work.organization_id, ChemicalWorkType.by_work(work).map(&:chemical).map(&:id), work.work_kind.chemical_kinds.pluck(:chemical_type_id), work.chemicals.pluck(:chemical_id))
             (
-                  chemicals.id IN (SELECT chemical_id FROM chemical_terms WHERE term = ?)
+                  chemicals.id IN (SELECT chemical_id FROM chemical_terms WHERE term = ? AND organization_id = ?)
               AND chemicals.id IN (?)
               AND chemicals.chemical_type_id IN (?)
             )#{' '}
@@ -68,8 +78,9 @@ class Chemical < ApplicationRecord
       ORDER
   }
 
-  scope :list, lambda {
+  scope :list, lambda { |organization = nil|
     kept.includes(:chemical_type)
+      .then { |base| organization ? base.for_organization(organization) : base }
       .order(Arel.sql("chemical_types.display_order, chemical_types.id, chemicals.phonetic, chemicals.display_order, chemicals.id"))
   }
 
@@ -81,10 +92,11 @@ class Chemical < ApplicationRecord
       .order(Arel.sql("chemical_types.display_order, chemical_types.id, chemicals.phonetic, chemicals.display_order, chemicals.id"))
   }
 
-  scope :for_stock, lambda { |term|
+  scope :for_stock, lambda { |term, organization = nil|
     joins(:chemical_type)
       .with_deleted
-      .where(chemicals: { id: ChemicalTerm.where(term: term).select("chemical_id") })
+      .then { |base| organization ? base.for_organization(organization) : base }
+      .where(chemicals: { id: ChemicalTerm.usual(term, organization).select("chemical_id") })
       .order(Arel.sql("chemical_types.display_order, chemical_types.id, chemicals.phonetic, chemicals.display_order, chemicals.id"))
   }
 
@@ -108,7 +120,7 @@ class Chemical < ApplicationRecord
   end
 
   def this_term?(term)
-    chemical_terms.exists?(term: term)
+    chemical_terms.exists?(term: term, organization_id: organization_id)
   end
 
   def base_unit_name
@@ -161,9 +173,9 @@ class Chemical < ApplicationRecord
 
   def save_term
     if ActiveRecord::Type::Boolean.new.cast(@this_term_flag)
-      ChemicalTerm.create(term: @term, chemical_id: id) unless chemical_terms.exists?(term: @term)
+      chemical_terms.create(term: @term, organization_id: organization_id) unless chemical_terms.exists?(term: @term, organization_id: organization_id)
     else
-      chemical_terms.where(term: @term).destroy_all
+      chemical_terms.where(term: @term, organization_id: organization_id).destroy_all
     end
   end
 end

--- a/app/models/chemical_inventory.rb
+++ b/app/models/chemical_inventory.rb
@@ -8,16 +8,29 @@
 #  created_at                            :datetime         not null
 #  updated_at                            :datetime         not null
 #  chemical_adjust_type_id(在庫調整種別) :integer          default(NULL), not null
+#  organization_id(組織)                 :bigint           not null
+#
+# Indexes
+#
+#  index_chemical_inventories_on_organization_id                 (organization_id)
+#  index_chemical_inventories_on_organization_id_and_checked_on  (organization_id,checked_on)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
 #
 
 class ChemicalInventory < ApplicationRecord
   enum :chemical_adjust_type_id, { inventory: 1, stored: 2, shipping: 3 }
+
+  belongs_to :organization
 
   validates :name, presence: true, length: { maximum: 40 }
   validates :checked_on, presence: true
   has_many :stocks, class_name: 'ChemicalStock', dependent: :destroy
   accepts_nested_attributes_for :stocks, allow_destroy: true
 
+  scope :for_organization, ->(organization) { where(organization_id: organization.is_a?(Organization) ? organization.id : organization) }
   scope :inventories, -> { where(chemical_adjust_type_id: :inventory).order(:checked_on) }
   scope :stores, -> { where(chemical_adjust_type_id: :stored).order(:checked_on) }
 end

--- a/app/models/chemical_stock.rb
+++ b/app/models/chemical_stock.rb
@@ -15,18 +15,33 @@
 #  updated_at                      :datetime         not null
 #  chemical_id(薬剤)               :integer          not null
 #  chemical_inventory_id(薬剤棚卸) :integer
+#  organization_id(組織)           :bigint           not null
 #  work_chemical_id(薬剤使用)      :integer
+#
+# Indexes
+#
+#  idx_on_organization_id_chemical_id_stock_on_ccf855096c  (organization_id,chemical_id,stock_on)
+#  index_chemical_stocks_on_organization_id                (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
 #
 
 class ChemicalStock < ApplicationRecord
+  belongs_to :organization
   belongs_to :chemical
   belongs_to :work_chemical
   belongs_to :chemical_inventory
 
-  validates :chemical_id, uniqueness: { scope: :chemical_inventory }, if: :valid_chemical_id?
+  validates :chemical_id, uniqueness: { scope: [:organization_id, :chemical_inventory_id] }, if: :valid_chemical_id?
+  validate :associations_same_organization
 
-  scope :usual, lambda { |chemical_id|
+  scope :for_organization, ->(organization) { where(organization_id: organization.is_a?(Organization) ? organization.id : organization) }
+
+  scope :usual, lambda { |chemical_id, organization = nil|
     where(chemical_id: chemical_id)
+      .then { |base| organization ? base.for_organization(organization) : base }
       .order(:stock_on, :id)
   }
 
@@ -37,6 +52,7 @@ class ChemicalStock < ApplicationRecord
     if chemical_inventory_id
       self.name = chemical_inventory.name
       self.stock_on = chemical_inventory.checked_on
+      self.organization_id = chemical_inventory.organization_id
     end
   end
 
@@ -47,11 +63,11 @@ class ChemicalStock < ApplicationRecord
   end
 
   def self.refresh(organization_id, chemical_id)
-    start_date = ChemicalStock.where(chemical_id: chemical_id).minimum(:stock_on)
-    from_work(chemical_id, start_date)
+    start_date = ChemicalStock.for_organization(organization_id).where(chemical_id: chemical_id).minimum(:stock_on)
+    from_work(organization_id, chemical_id, start_date)
     create_begin(organization_id, chemical_id, start_date)
     tmp_stock = 0
-    ChemicalStock.usual(chemical_id).each do |stock|
+    ChemicalStock.usual(chemical_id, organization_id).each do |stock|
       if stock.inventory.nil?
         stock.adjust = (stock.stored || 0) - (stock.using || 0) - (stock.shipping || 0)
         stock.stock = tmp_stock + stock.adjust
@@ -66,21 +82,23 @@ class ChemicalStock < ApplicationRecord
 
   def self.create_begin(organization_id, chemical_id, start_date)
     System.where("start_date > ? AND organization_id = ?", start_date, organization_id).order(:start_date).each do |sys|
-      next if ChemicalStock.exists?(["chemical_id = ? AND stock_on = ?", chemical_id, sys.start_date])
+      next if ChemicalStock.exists?(chemical_id: chemical_id, organization_id: organization_id, stock_on: sys.start_date)
 
       ChemicalStock.create(
         name: "期首在庫",
         stock_on: sys.start_date,
-        chemical_id: chemical_id
+        chemical_id: chemical_id,
+        organization_id: organization_id
       )
     end
   end
 
-  def self.from_work(chemical_id, start_date)
-    ChemicalStock.where(chemical_id: chemical_id).where.not(work_chemical_id: nil).update_all("\"using\" = 0")
-    WorkChemical.for_stock(chemical_id, start_date).each do |work_chemical|
+  def self.from_work(organization_id, chemical_id, start_date)
+    ChemicalStock.for_organization(organization_id).where(chemical_id: chemical_id).where.not(work_chemical_id: nil).update_all("\"using\" = 0")
+    WorkChemical.for_stock(chemical_id, start_date, organization_id).each do |work_chemical|
       stock = ChemicalStock.find_by(work_chemical_id: work_chemical.id)
       if stock
+        stock.organization_id = organization_id
         stock.stock_on = work_chemical.work.worked_at
         stock.name = "#{work_chemical.work.work_type.name}(#{work_chemical.work.work_kind.name})"
         stock.using = work_chemical.quantity_for_stock
@@ -89,13 +107,14 @@ class ChemicalStock < ApplicationRecord
         ChemicalStock.create(
           work_chemical_id: work_chemical.id,
           chemical_id: chemical_id,
+          organization_id: organization_id,
           stock_on: work_chemical.work.worked_at,
           name: "#{work_chemical.work.work_type.name}(#{work_chemical.work.work_kind.name})",
           using: work_chemical.quantity_for_stock
         )
       end
     end
-    ChemicalStock.where(chemical_id: chemical_id).where.not(work_chemical_id: nil).where(using: 0).destroy_all
+    ChemicalStock.for_organization(organization_id).where(chemical_id: chemical_id).where.not(work_chemical_id: nil).where(using: 0).destroy_all
   end
 
   def editable?
@@ -115,5 +134,15 @@ class ChemicalStock < ApplicationRecord
   def stored_stock=(value)
     self.stored = 0
     @stored_stock_value = value
+  end
+
+  private
+
+  def associations_same_organization
+    return if organization_id.blank?
+
+    errors.add(:chemical_id, :invalid) if chemical.present? && chemical.organization_id != organization_id
+    errors.add(:chemical_inventory_id, :invalid) if chemical_inventory.present? && chemical_inventory.organization_id != organization_id
+    errors.add(:work_chemical_id, :invalid) if work_chemical.present? && work_chemical.work.organization_id != organization_id
   end
 end

--- a/app/models/chemical_stock.rb
+++ b/app/models/chemical_stock.rb
@@ -49,11 +49,11 @@ class ChemicalStock < ApplicationRecord
   before_save :save_stored
 
   def save_inventory
-    if chemical_inventory_id
-      self.name = chemical_inventory.name
-      self.stock_on = chemical_inventory.checked_on
-      self.organization_id = chemical_inventory.organization_id
-    end
+    return unless chemical_inventory
+
+    self.name = chemical_inventory.name
+    self.stock_on = chemical_inventory.checked_on
+    self.organization_id = chemical_inventory.organization_id
   end
 
   def save_stored

--- a/app/models/chemical_stock.rb
+++ b/app/models/chemical_stock.rb
@@ -64,6 +64,9 @@ class ChemicalStock < ApplicationRecord
 
   def self.refresh(organization_id, chemical_id)
     start_date = ChemicalStock.for_organization(organization_id).where(chemical_id: chemical_id).minimum(:stock_on)
+    start_date ||= System.min_date(organization_id)
+    return if start_date.nil?
+
     from_work(organization_id, chemical_id, start_date)
     create_begin(organization_id, chemical_id, start_date)
     tmp_stock = 0
@@ -96,7 +99,7 @@ class ChemicalStock < ApplicationRecord
   def self.from_work(organization_id, chemical_id, start_date)
     ChemicalStock.for_organization(organization_id).where(chemical_id: chemical_id).where.not(work_chemical_id: nil).update_all("\"using\" = 0")
     WorkChemical.for_stock(chemical_id, start_date, organization_id).each do |work_chemical|
-      stock = ChemicalStock.find_by(work_chemical_id: work_chemical.id)
+      stock = ChemicalStock.for_organization(organization_id).find_by(work_chemical_id: work_chemical.id)
       if stock
         stock.organization_id = organization_id
         stock.stock_on = work_chemical.work.worked_at

--- a/app/models/chemical_term.rb
+++ b/app/models/chemical_term.rb
@@ -2,32 +2,45 @@
 #
 # Table name: chemical_terms(薬剤年度別利用マスタ)
 #
-#  id                :integer          not null, primary key
-#  price(価格)       :decimal(6, )     default(0), not null
-#  term(年度(期))    :integer          not null
-#  chemical_id(薬剤) :integer          not null
+#  id                    :integer          not null, primary key
+#  price(価格)           :decimal(6, )     default(0), not null
+#  term(年度(期))        :integer          not null
+#  chemical_id(薬剤)     :integer          not null
+#  organization_id(組織) :bigint           not null
 #
 # Indexes
 #
-#  index_chemical_terms_on_chemical_id_and_term  (chemical_id,term) UNIQUE
+#  idx_on_organization_id_chemical_id_term_38ad97d24a  (organization_id,chemical_id,term) UNIQUE
+#  index_chemical_terms_on_organization_id             (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
 #
 
 class ChemicalTerm < ApplicationRecord
+  belongs_to :organization
   belongs_to :chemical, -> { with_deleted }
   has_many :chemical_work_types, dependent: :destroy
   has_many :work_types, through: :chemical_work_types
 
-  scope :usual, lambda { |term|
+  validate :chemical_same_organization
+
+  scope :for_organization, ->(organization) { where(organization_id: organization.is_a?(Organization) ? organization.id : organization) }
+
+  scope :usual, lambda { |term, organization = nil|
     joins(chemical: :chemical_type).includes(:chemical)
       .where(term: term)
+      .then { |base| organization ? base.for_organization(organization) : base }
       .order(Arel.sql(<<SQL.squish))
         chemical_types.display_order, chemical_types.id, chemicals.phonetic, chemicals.display_order, chemicals.id
 SQL
   }
 
-  scope :by_type, lambda { |term, chemical_type_id|
+  scope :by_type, lambda { |term, chemical_type_id, organization = nil|
     joins(:chemical)
       .where(term: term)
+      .then { |base| organization ? base.for_organization(organization) : base }
       .where(chemicals: { chemical_type_id: chemical_type_id })
       .order("chemicals.phonetic, chemicals.display_order, chemicals.id")
       .select("chemicals.*, chemical_terms.id AS chemical_term_id")
@@ -37,30 +50,42 @@ SQL
   EXISTS (SELECT * FROM chemical_kinds WHERE chemical_kinds.chemical_type_id = chemicals.chemical_type_id)
 SQL
 
-  def self.regist_price(params)
+  def self.regist_price(params, organization = nil)
     params.each do |param|
-      ChemicalTerm.find(param[:id]).update(price: param[:price] || 0)
+      base = organization ? for_organization(organization) : all
+      base.find(param[:id]).update(price: param[:price] || 0)
     end
   end
 
   delegate :name, to: :chemical, prefix: true
 
-  def self.create_for_plans(params, term)
-    ChemicalTerm.destroy_all
+  def self.create_for_plans(params, term, organization)
+    organization_id = organization.is_a?(Organization) ? organization.id : organization
+    ChemicalTerm.for_organization(organization_id).where(term: term).destroy_all
     params[:chemicals].each do |chemical_id|
-      ChemicalTerm.create(term: term, chemical_id: chemical_id)
+      ChemicalTerm.create(term: term, chemical_id: chemical_id, organization_id: organization_id)
     end
   end
 
-  def self.annual_update(old_term, new_term)
-    ChemicalTerm.where(term: old_term).find_each do |chemical_term|
-      unless ChemicalTerm.exists?(term: new_term, chemical_id: chemical_term.chemical_id)
+  def self.annual_update(old_term, new_term, organization)
+    organization_id = organization.is_a?(Organization) ? organization.id : organization
+    ChemicalTerm.for_organization(organization_id).where(term: old_term).find_each do |chemical_term|
+      unless ChemicalTerm.exists?(term: new_term, chemical_id: chemical_term.chemical_id, organization_id: organization_id)
         ChemicalTerm.create(
           chemical_id: chemical_term.chemical_id,
+          organization_id: organization_id,
           term: new_term,
           price: chemical_term.price
         )
       end
     end
+  end
+
+  private
+
+  def chemical_same_organization
+    return if organization_id.blank? || chemical.blank? || chemical.organization_id == organization_id
+
+    errors.add(:chemical_id, :invalid)
   end
 end

--- a/app/models/chemical_work_type.rb
+++ b/app/models/chemical_work_type.rb
@@ -25,8 +25,8 @@ class ChemicalWorkType < ApplicationRecord
   scope :usable, ->(chemical_term) { where(chemical_term_id: chemical_term).where("quantity > 0") }
   scope :by_work, lambda { |work|
     joins(chemical_term: :chemical)
-      .where(["chemical_work_types.work_type_id IN (?) AND chemical_work_types.quantity > 0 AND chemical_terms.term = ?",
-              work.exact_work_types.map(&:id), work.term])
+      .where(["chemical_work_types.work_type_id IN (?) AND chemical_work_types.quantity > 0 AND chemical_terms.term = ? AND chemical_terms.organization_id = ?",
+              work.exact_work_types.map(&:id), work.term, work.organization_id])
   }
 
   def self.regist_quantity(params)
@@ -46,19 +46,27 @@ class ChemicalWorkType < ApplicationRecord
 
   def self.by_work_chemical(work_chemical, work_type_id)
     joins(chemical_term: :chemical)
-      .find_by(<<SQL.squish, work_type_id, work_chemical.work.term, work_chemical.chemical_id)
+      .find_by(<<SQL.squish, work_type_id, work_chemical.work.term, work_chemical.chemical_id, work_chemical.work.organization_id)
           chemical_work_types.work_type_id = ?#{' '}
       AND chemical_terms.term = ?
       AND chemical_terms.chemical_id = ?
+      AND chemical_terms.organization_id = ?
 SQL
   end
 
-  def self.annual_update(old_term, new_term)
-    ChemicalWorkType.joins(:chemical_term).where(chemical_terms: { term: old_term }).find_each do |chemical_work_type|
+  def self.annual_update(old_term, new_term, organization = nil)
+    organization_id = organization.is_a?(Organization) ? organization.id : organization
+    base = ChemicalWorkType.joins(:chemical_term).where(chemical_terms: { term: old_term })
+    base = base.where(chemical_terms: { organization_id: organization_id }) if organization_id
+    base.find_each do |chemical_work_type|
       next if chemical_work_type.quantity.zero?
       next unless WorkTypeTerm.where(term: new_term, work_type_id: chemical_work_type.work_type_id)
 
-      chemical_term = ChemicalTerm.find_by(chemical_id: chemical_work_type.chemical_term.chemical_id, term: new_term)
+      chemical_term = ChemicalTerm.find_by(
+        chemical_id: chemical_work_type.chemical_term.chemical_id,
+        term: new_term,
+        organization_id: chemical_work_type.chemical_term.organization_id
+      )
       next if chemical_term.nil?
       next if ChemicalWorkType.exists?(chemical_term_id: chemical_term, work_type_id: chemical_work_type.work_type_id)
 

--- a/app/models/work_chemical.rb
+++ b/app/models/work_chemical.rb
@@ -67,10 +67,11 @@ class WorkChemical < ApplicationRecord
     end
   }
 
-  scope :for_stock, lambda { |chemical_id, start_date|
+  scope :for_stock, lambda { |chemical_id, start_date, organization = nil|
     joins(:work)
       .includes(:chemical)
       .where("works.worked_at >= ? AND work_chemicals.chemical_id = ?", start_date, chemical_id)
+      .then { |base| organization ? base.where(works: { organization_id: organization.is_a?(Organization) ? organization.id : organization }) : base }
       .order("works.worked_at, works.id")
   }
 
@@ -109,7 +110,7 @@ class WorkChemical < ApplicationRecord
 
   def areas
     if chemical_group_no.zero? || work.work_lands.where(chemical_group_no: chemical_group_no).empty?
-      chemical_term = ChemicalTerm.find_by(term: work.term, chemical_id: chemical_id)
+      chemical_term = ChemicalTerm.find_by(term: work.term, chemical_id: chemical_id, organization_id: work.organization_id)
       work_type_ids = chemical_term ? chemical_term.work_types.map(&:id) : [work.work_type_id]
       land_ids = LandCost.by_work_type(work_type_ids, work.worked_at).by_land(work.work_lands.map(&:land_id)).map(&:land_id)
       Land.where(id: land_ids).sum(:area)

--- a/app/models/work_land.rb
+++ b/app/models/work_land.rb
@@ -110,7 +110,7 @@ class WorkLand < ApplicationRecord
     work.work_chemicals.each do |work_chemical|
       next if chemical_group_no.positive? && work_chemical.chemical_group_no != chemical_group_no
 
-      chemical_term = ChemicalTerm.find_by(chemical_id: work_chemical.chemical_id, term: work_chemical.work.term)
+      chemical_term = ChemicalTerm.find_by(chemical_id: work_chemical.chemical_id, term: work_chemical.work.term, organization_id: work_chemical.work.organization_id)
       next unless chemical_term
 
       chemical_work_type = ChemicalWorkType.find_by(chemical_term_id: chemical_term, work_type_id: work_type_id)

--- a/app/views/chemicals/inventories/edit.html.erb
+++ b/app/views/chemicals/inventories/edit.html.erb
@@ -41,7 +41,7 @@
             <td>
               <%= fs.select :chemical_id, 
                 options_from_collection_for_select(
-                  ChemicalDecorator.decorate_collection(Chemical.for_stock(stock_system.term).by_type(fs.object&.chemical&.chemical_type_id || chemical_types.first.id)),
+                  ChemicalDecorator.decorate_collection(Chemical.for_stock(stock_system.term, current_organization).by_type(fs.object&.chemical&.chemical_type_id || chemical_types.first.id)),
                   :id, :stock_name, fs.object&.chemical_id), {},
                 class: "form-select chemical", data: {index: fs.index}
               %>
@@ -73,7 +73,7 @@
     </div>
   </div>
 <% end %>
-<% ChemicalDecorator.decorate_collection(Chemical.for_stock(stock_system.term)).each do |chemical| %>
+<% ChemicalDecorator.decorate_collection(Chemical.for_stock(stock_system.term, current_organization)).each do |chemical| %>
 <%= hidden_field_tag nil, chemical.stock_name,
   data: {chemical_type: chemical.chemical_type_id, id: chemical.id} %>
 <% end %>

--- a/app/views/chemicals/stores/edit.html.erb
+++ b/app/views/chemicals/stores/edit.html.erb
@@ -41,7 +41,7 @@
             <td>
               <%= fs.select :chemical_id, 
                 options_from_collection_for_select(
-                  ChemicalDecorator.decorate_collection(Chemical.for_stock(stock_system.term).by_type(fs.object&.chemical&.chemical_type_id || chemical_types.first.id)),
+                  ChemicalDecorator.decorate_collection(Chemical.for_stock(stock_system.term, current_organization).by_type(fs.object&.chemical&.chemical_type_id || chemical_types.first.id)),
                   :id, :stored_name, fs.object&.chemical_id), {},
                 class: "form-select chemical", data: {index: fs.index}
               %>
@@ -73,7 +73,7 @@
     </div>
   </div>
 <% end %>
-<% ChemicalDecorator.decorate_collection(Chemical.for_stock(stock_system.term)).each do |chemical| %>
+<% ChemicalDecorator.decorate_collection(Chemical.for_stock(stock_system.term, current_organization)).each do |chemical| %>
 <%= hidden_field_tag nil, chemical.stored_name, 
   data: {chemical_type: chemical.chemical_type_id, id: chemical.id} %>
 <% end %>

--- a/db/migrate/20260511090000_add_organization_to_chemical_tables.rb
+++ b/db/migrate/20260511090000_add_organization_to_chemical_tables.rb
@@ -1,0 +1,70 @@
+class AddOrganizationToChemicalTables < ActiveRecord::Migration[8.1]
+  def up
+    default_org_id = select_value("SELECT id FROM organizations ORDER BY id LIMIT 1").to_i
+    raise ActiveRecord::IrreversibleMigration, "organizations is empty" if default_org_id.zero?
+
+    add_reference :chemicals, :organization, null: true, foreign_key: true, comment: "組織"
+    add_reference :chemical_terms, :organization, null: true, foreign_key: true, comment: "組織"
+    add_reference :chemical_inventories, :organization, null: true, foreign_key: true, comment: "組織"
+    add_reference :chemical_stocks, :organization, null: true, foreign_key: true, comment: "組織"
+
+    execute "UPDATE chemicals SET organization_id = #{default_org_id}"
+    execute "UPDATE chemical_inventories SET organization_id = #{default_org_id}"
+
+    execute <<~SQL.squish
+      UPDATE chemical_terms
+         SET organization_id = chemicals.organization_id
+        FROM chemicals
+       WHERE chemical_terms.chemical_id = chemicals.id
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE chemical_stocks
+         SET organization_id = chemicals.organization_id
+        FROM chemicals
+       WHERE chemical_stocks.chemical_id = chemicals.id
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE chemical_stocks
+         SET organization_id = chemical_inventories.organization_id
+        FROM chemical_inventories
+       WHERE chemical_stocks.chemical_inventory_id = chemical_inventories.id
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE chemical_stocks
+         SET organization_id = works.organization_id
+        FROM work_chemicals
+        INNER JOIN works ON works.id = work_chemicals.work_id
+       WHERE chemical_stocks.work_chemical_id = work_chemicals.id
+    SQL
+
+    remove_index :chemical_terms, column: [:chemical_id, :term]
+    add_index :chemical_terms, [:organization_id, :chemical_id, :term], unique: true
+    add_index :chemical_stocks, [:organization_id, :chemical_id, :stock_on]
+    add_index :chemical_inventories, [:organization_id, :checked_on]
+
+    change_column_null :chemicals, :organization_id, false
+    change_column_null :chemical_terms, :organization_id, false
+    change_column_null :chemical_inventories, :organization_id, false
+    change_column_null :chemical_stocks, :organization_id, false
+  end
+
+  def down
+    change_column_null :chemical_stocks, :organization_id, true
+    change_column_null :chemical_inventories, :organization_id, true
+    change_column_null :chemical_terms, :organization_id, true
+    change_column_null :chemicals, :organization_id, true
+
+    remove_index :chemical_inventories, column: [:organization_id, :checked_on]
+    remove_index :chemical_stocks, column: [:organization_id, :chemical_id, :stock_on]
+    remove_index :chemical_terms, column: [:organization_id, :chemical_id, :term]
+    add_index :chemical_terms, [:chemical_id, :term], unique: true
+
+    remove_reference :chemical_stocks, :organization, foreign_key: true
+    remove_reference :chemical_inventories, :organization, foreign_key: true
+    remove_reference :chemical_terms, :organization, foreign_key: true
+    remove_reference :chemicals, :organization, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_11_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgroonga"
@@ -94,7 +94,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_090000) do
     t.integer "chemical_adjust_type_id", default: 0, null: false, comment: "在庫調整種別"
     t.datetime "created_at", null: false
     t.string "name", limit: 40, default: "", null: false, comment: "棚卸名称"
+    t.bigint "organization_id", null: false, comment: "組織"
     t.datetime "updated_at", null: false
+    t.index ["organization_id", "checked_on"], name: "index_chemical_inventories_on_organization_id_and_checked_on"
+    t.index ["organization_id"], name: "index_chemical_inventories_on_organization_id"
   end
 
   create_table "chemical_kinds", id: { type: :serial, comment: "作業種別薬剤種別利用マスタ" }, comment: "作業種別薬剤種別利用マスタ", force: :cascade do |t|
@@ -110,6 +113,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_090000) do
     t.datetime "created_at", null: false
     t.decimal "inventory", precision: 8, scale: 1, comment: "棚卸量"
     t.string "name", limit: 40, default: "", null: false, comment: "在庫名称"
+    t.bigint "organization_id", null: false, comment: "組織"
     t.decimal "shipping", precision: 7, scale: 1, comment: "出庫量"
     t.decimal "stock", precision: 8, scale: 1, default: "0.0", null: false, comment: "在庫量"
     t.date "stock_on", null: false, comment: "在庫日"
@@ -117,13 +121,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_090000) do
     t.datetime "updated_at", null: false
     t.decimal "using", precision: 7, scale: 1, comment: "使用量"
     t.integer "work_chemical_id", comment: "薬剤使用"
+    t.index ["organization_id", "chemical_id", "stock_on"], name: "idx_on_organization_id_chemical_id_stock_on_ccf855096c"
+    t.index ["organization_id"], name: "index_chemical_stocks_on_organization_id"
   end
 
   create_table "chemical_terms", id: :serial, comment: "薬剤年度別利用マスタ", force: :cascade do |t|
     t.integer "chemical_id", null: false, comment: "薬剤"
+    t.bigint "organization_id", null: false, comment: "組織"
     t.decimal "price", precision: 6, default: "0", null: false, comment: "価格"
     t.integer "term", null: false, comment: "年度(期)"
-    t.index ["chemical_id", "term"], name: "index_chemical_terms_on_chemical_id_and_term", unique: true
+    t.index ["organization_id", "chemical_id", "term"], name: "idx_on_organization_id_chemical_id_term_38ad97d24a", unique: true
+    t.index ["organization_id"], name: "index_chemical_terms_on_organization_id"
   end
 
   create_table "chemical_types", id: { type: :serial, comment: "薬剤種別マスタ" }, comment: "薬剤種別マスタ", force: :cascade do |t|
@@ -153,6 +161,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_090000) do
     t.datetime "deleted_at", precision: nil
     t.integer "display_order", default: 0, null: false, comment: "表示順"
     t.string "name", limit: 20, null: false, comment: "薬剤名称"
+    t.bigint "organization_id", null: false, comment: "組織"
     t.string "phonetic", limit: 40, default: "", null: false, comment: "薬剤ふりがな"
     t.decimal "stock_quantity", precision: 6, default: "0", null: false, comment: "在庫数"
     t.string "stock_unit", limit: 2, default: "", null: false, comment: "在庫単位"
@@ -160,6 +169,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_090000) do
     t.datetime "updated_at", precision: nil
     t.string "url", limit: 255, default: "", null: false, comment: "URL"
     t.index ["deleted_at"], name: "index_chemicals_on_deleted_at"
+    t.index ["organization_id"], name: "index_chemicals_on_organization_id"
   end
 
   create_table "cleaning_cleaning_targets", comment: "清掃対象", force: :cascade do |t|
@@ -1288,6 +1298,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_090000) do
     t.index ["organization_id"], name: "index_works_on_organization_id"
   end
 
+  add_foreign_key "chemical_inventories", "organizations"
+  add_foreign_key "chemical_stocks", "organizations"
+  add_foreign_key "chemical_terms", "organizations"
+  add_foreign_key "chemicals", "organizations"
   add_foreign_key "fixes", "organizations"
   add_foreign_key "homes", "organizations"
   add_foreign_key "lands", "organizations"

--- a/test/controllers/lands/chemicals_controller_test.rb
+++ b/test/controllers/lands/chemicals_controller_test.rb
@@ -69,8 +69,8 @@ class Lands::ChemicalsControllerTest < ActionDispatch::IntegrationTest
     LandCost.create!(land: map_land, work_type: work_types(:work_type_koshi), activated_on: Date.new(2015, 1, 1))
     LandCost.create!(land: excluded_land, work_type: work_types(:work_type_koshi), activated_on: Date.new(2015, 1, 1))
 
-    chemical = Chemical.create!(chemical_type: chemical_types(:chemical_types0), name: "試験表示薬剤", phonetic: "しけんひょうじやくざい", display_order: 999)
-    chemical_term = ChemicalTerm.create!(chemical: chemical, term: 2015)
+    chemical = Chemical.create!(organization: organizations(:org), chemical_type: chemical_types(:chemical_types0), name: "試験表示薬剤", phonetic: "しけんひょうじやくざい", display_order: 999)
+    chemical_term = ChemicalTerm.create!(organization: organizations(:org), chemical: chemical, term: 2015)
     ChemicalWorkType.create!(chemical_term: chemical_term, work_type: work_types(:work_type_koshi), quantity: 1.0)
 
     WorkLand.create!(work: taue_work, land: map_land, work_type_id: 11)

--- a/test/controllers/tablets/lands/chemicals_controller_test.rb
+++ b/test/controllers/tablets/lands/chemicals_controller_test.rb
@@ -23,8 +23,8 @@ class Tablets::Lands::ChemicalsControllerTest < ActionDispatch::IntegrationTest
     map_land = lands(:lands1)
     LandCost.create!(land: map_land, work_type: work_types(:work_type_koshi), activated_on: Date.new(2015, 1, 1))
 
-    chemical = Chemical.create!(chemical_type: chemical_types(:chemical_types0), name: "試験表示薬剤T", phonetic: "しけんひょうじやくざいてぃ", display_order: 999)
-    chemical_term = ChemicalTerm.create!(chemical: chemical, term: 2015)
+    chemical = Chemical.create!(organization: organizations(:org), chemical_type: chemical_types(:chemical_types0), name: "試験表示薬剤T", phonetic: "しけんひょうじやくざいてぃ", display_order: 999)
+    chemical_term = ChemicalTerm.create!(organization: organizations(:org), chemical: chemical, term: 2015)
     ChemicalWorkType.create!(chemical_term: chemical_term, work_type: work_types(:work_type_koshi), quantity: 1.0)
 
     WorkLand.create!(work: taue_work, land: map_land, work_type_id: 11)

--- a/test/fixtures/chemical_inventories.yml
+++ b/test/fixtures/chemical_inventories.yml
@@ -8,6 +8,16 @@
 #  created_at                            :datetime         not null
 #  updated_at                            :datetime         not null
 #  chemical_adjust_type_id(在庫調整種別) :integer          default(NULL), not null
+#  organization_id(組織)                 :bigint           not null
+#
+# Indexes
+#
+#  index_chemical_inventories_on_organization_id                 (organization_id)
+#  index_chemical_inventories_on_organization_id_and_checked_on  (organization_id,checked_on)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
 #
 
 # This model initially had no columns defined. If you add columns to the
@@ -16,26 +26,31 @@
 #
 
 inventory1:
+  organization_id: 1
   checked_on: '2015-12-15'
   name: '年末棚卸'
   chemical_adjust_type_id: 1
 
 store1:
+  organization_id: 1
   checked_on: '2015-12-16'
   name: '年末納品'
   chemical_adjust_type_id: 2
 
 inventory21:
+  organization_id: 1
   checked_on: '2015-01-01'
   name: '初期在庫'
   chemical_adjust_type_id: 1
 
 store2:
+  organization_id: 1
   checked_on: '2015-03-01'
   name: '納品1'
   chemical_adjust_type_id: 2
 
 inventory22:
+  organization_id: 1
   checked_on: '2015-12-31'
   name: '年末棚卸'
   chemical_adjust_type_id: 1

--- a/test/fixtures/chemical_stocks.yml
+++ b/test/fixtures/chemical_stocks.yml
@@ -15,7 +15,17 @@
 #  updated_at                      :datetime         not null
 #  chemical_id(薬剤)               :integer          not null
 #  chemical_inventory_id(薬剤棚卸) :integer
+#  organization_id(組織)           :bigint           not null
 #  work_chemical_id(薬剤使用)      :integer
+#
+# Indexes
+#
+#  idx_on_organization_id_chemical_id_stock_on_ccf855096c  (organization_id,chemical_id,stock_on)
+#  index_chemical_stocks_on_organization_id                (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
 #
 
 # This model initially had no columns defined. If you add columns to the
@@ -23,6 +33,7 @@
 # below each fixture, per the syntax in the comments below
 #
 stock_inventory:
+  organization_id: 1
   chemical_id: '3'
   chemical_inventory: inventory1
   stock_on: '2015-12-15'
@@ -30,6 +41,7 @@ stock_inventory:
   inventory: 200
 
 stock_store:
+  organization_id: 1
   chemical_id: '3'
   chemical_inventory: store1
   stock_on: '2015-12-16'
@@ -37,12 +49,14 @@ stock_store:
   stored: 300
 
 stock_edit:
+  organization_id: 1
   chemical_id: '3'
   stock_on: '2015-12-17'
   name: '手入力'
   stored: 500
 
 stock_model1:
+  organization_id: 1
   chemical_id: '4'
   stock_on: '2015-01-01'
   chemical_inventory: inventory21
@@ -50,6 +64,7 @@ stock_model1:
   inventory: 60
 
 stock_model2:
+  organization_id: 1
   chemical_id: '4'
   chemical_inventory: store2
   stock_on: '2015-03-01'
@@ -57,18 +72,21 @@ stock_model2:
   stored: 20
 
 stock_model4:
+  organization_id: 1
   chemical_id: '4'
   name: '手入力入庫'
   stock_on: '2015-04-01'
   stored: 15
 
 stock_model5:
+  organization_id: 1
   chemical_id: '4'
   name: '手入力出庫'
   stock_on: '2015-05-01'
   shipping: 20
 
 stock_model6:
+  organization_id: 1
   chemical_id: '4'
   name: '年末棚卸'
   chemical_inventory: inventory22
@@ -76,6 +94,7 @@ stock_model6:
   inventory: 20
 
 stock_for_test:
+  organization_id: 1
   chemical_id: '5'
   stock_on: '2015-12-16'
   name: '年末納品'

--- a/test/fixtures/chemical_terms.yml
+++ b/test/fixtures/chemical_terms.yml
@@ -60,7 +60,7 @@ chemical_term_3_2016:
   term: '2016'
 
 
-chemical_term_4_2012:
+chemical_term_4_2010:
   organization_id: 1
   chemical_id: '4'
   term: '2010'

--- a/test/fixtures/chemical_terms.yml
+++ b/test/fixtures/chemical_terms.yml
@@ -2,512 +2,618 @@
 #
 # Table name: chemical_terms(薬剤年度別利用マスタ)
 #
-#  id                :integer          not null, primary key
-#  price(価格)       :decimal(6, )     default(0), not null
-#  term(年度(期))    :integer          not null
-#  chemical_id(薬剤) :integer          not null
+#  id                    :integer          not null, primary key
+#  price(価格)           :decimal(6, )     default(0), not null
+#  term(年度(期))        :integer          not null
+#  chemical_id(薬剤)     :integer          not null
+#  organization_id(組織) :bigint           not null
 #
 # Indexes
 #
-#  index_chemical_terms_on_chemical_id_and_term  (chemical_id,term) UNIQUE
+#  idx_on_organization_id_chemical_id_term_38ad97d24a  (organization_id,chemical_id,term) UNIQUE
+#  index_chemical_terms_on_organization_id             (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
 #
 
 chemical_term_3_2010:
+  organization_id: 1
   chemical_id: '3'
   term: '2010'
 
 
 chemical_term_3_2011:
+  organization_id: 1
   chemical_id: '3'
   term: '2011'
 
 
 chemical_term_3_2014:
+  organization_id: 1
   chemical_id: '3'
   term: '2014'
 
 
 chemical_term_3_2013:
+  organization_id: 1
   chemical_id: '3'
   term: '2013'
 
 
 chemical_term_3_2015:
+  organization_id: 1
   chemical_id: '3'
   term: '2015'
 
 
 chemical_term_3_2012:
+  organization_id: 1
   chemical_id: '3'
   term: '2012'
 
 
 chemical_term_3_2016:
+  organization_id: 1
   chemical_id: '3'
   term: '2016'
 
 
 chemical_term_4_2012:
+  organization_id: 1
   chemical_id: '4'
   term: '2010'
 
 
 chemical_term_4_2011:
+  organization_id: 1
   chemical_id: '4'
   term: '2011'
 
 
 chemical_term_4_2014:
+  organization_id: 1
   chemical_id: '4'
   term: '2014'
 
 
 chemical_term_4_2013:
+  organization_id: 1
   chemical_id: '4'
   term: '2013'
 
 
 chemical_term_4_2015:
+  organization_id: 1
   chemical_id: '4'
   term: '2015'
 
 
 chemical_term_4_2012:
+  organization_id: 1
   chemical_id: '4'
   term: '2012'
 
 
 chemical_term_4_2016:
+  organization_id: 1
   chemical_id: '4'
   term: '2016'
 
 
 chemical_terms14:
+  organization_id: 1
   chemical_id: '6'
   term: '2010'
 
 
 chemical_terms15:
+  organization_id: 1
   chemical_id: '6'
   term: '2011'
 
 
 chemical_terms16:
+  organization_id: 1
   chemical_id: '6'
   term: '2014'
 
 
 chemical_terms17:
+  organization_id: 1
   chemical_id: '6'
   term: '2013'
 
 
 chemical_terms18:
+  organization_id: 1
   chemical_id: '6'
   term: '2015'
 
 
 chemical_terms19:
+  organization_id: 1
   chemical_id: '6'
   term: '2012'
 
 
 chemical_terms20:
+  organization_id: 1
   chemical_id: '6'
   term: '2016'
 
 
 chemical_terms21:
+  organization_id: 1
   chemical_id: '8'
   term: '2010'
 
 
 chemical_terms22:
+  organization_id: 1
   chemical_id: '8'
   term: '2011'
 
 
 chemical_terms23:
+  organization_id: 1
   chemical_id: '8'
   term: '2014'
 
 
 chemical_terms24:
+  organization_id: 1
   chemical_id: '8'
   term: '2013'
 
 
 chemical_terms25:
+  organization_id: 1
   chemical_id: '8'
   term: '2015'
 
 
 chemical_terms26:
+  organization_id: 1
   chemical_id: '8'
   term: '2012'
 
 
 chemical_terms27:
+  organization_id: 1
   chemical_id: '8'
   term: '2016'
 
 
 chemical_terms28:
+  organization_id: 1
   chemical_id: '9'
   term: '2010'
 
 
 chemical_terms29:
+  organization_id: 1
   chemical_id: '9'
   term: '2011'
 
 
 chemical_terms30:
+  organization_id: 1
   chemical_id: '9'
   term: '2014'
 
 
 chemical_terms31:
+  organization_id: 1
   chemical_id: '9'
   term: '2013'
 
 
 chemical_terms32:
+  organization_id: 1
   chemical_id: '9'
   term: '2015'
 
 
 chemical_terms33:
+  organization_id: 1
   chemical_id: '9'
   term: '2012'
 
 
 chemical_terms34:
+  organization_id: 1
   chemical_id: '9'
   term: '2016'
 
 
 chemical_terms35:
+  organization_id: 1
   chemical_id: '7'
   term: '2010'
 
 
 chemical_terms36:
+  organization_id: 1
   chemical_id: '7'
   term: '2011'
 
 
 chemical_terms37:
+  organization_id: 1
   chemical_id: '7'
   term: '2014'
 
 
 chemical_terms38:
+  organization_id: 1
   chemical_id: '7'
   term: '2013'
 
 
 chemical_terms39:
+  organization_id: 1
   chemical_id: '7'
   term: '2015'
 
 
 chemical_terms40:
+  organization_id: 1
   chemical_id: '7'
   term: '2012'
 
 
 chemical_terms41:
+  organization_id: 1
   chemical_id: '7'
   term: '2016'
 
 
 chemical_terms56:
+  organization_id: 1
   chemical_id: '1'
   term: '2010'
 
 
 chemical_terms57:
+  organization_id: 1
   chemical_id: '1'
   term: '2011'
 
 
 chemical_terms58:
+  organization_id: 1
   chemical_id: '1'
   term: '2014'
 
 
 chemical_terms59:
+  organization_id: 1
   chemical_id: '1'
   term: '2013'
 
 
 chemical_terms60:
+  organization_id: 1
   chemical_id: '1'
   term: '2015'
 
 
 chemical_terms61:
+  organization_id: 1
   chemical_id: '1'
   term: '2012'
 
 
 chemical_terms62:
+  organization_id: 1
   chemical_id: '1'
   term: '2016'
 
 
 chemical_terms63:
+  organization_id: 1
   chemical_id: '13'
   term: '2010'
 
 
 chemical_terms64:
+  organization_id: 1
   chemical_id: '13'
   term: '2011'
 
 
 chemical_terms65:
+  organization_id: 1
   chemical_id: '13'
   term: '2014'
 
 
 chemical_terms66:
+  organization_id: 1
   chemical_id: '13'
   term: '2013'
 
 
 chemical_terms67:
+  organization_id: 1
   chemical_id: '13'
   term: '2015'
 
 
 chemical_terms68:
+  organization_id: 1
   chemical_id: '13'
   term: '2012'
 
 
 chemical_terms69:
+  organization_id: 1
   chemical_id: '13'
   term: '2016'
 
 
 chemical_terms70:
+  organization_id: 1
   chemical_id: '2'
   term: '2010'
 
 
 chemical_terms71:
+  organization_id: 1
   chemical_id: '2'
   term: '2011'
 
 
 chemical_terms72:
+  organization_id: 1
   chemical_id: '2'
   term: '2014'
 
 
 chemical_terms73:
+  organization_id: 1
   chemical_id: '2'
   term: '2013'
 
 
 chemical_terms74:
+  organization_id: 1
   chemical_id: '2'
   term: '2015'
 
 
 chemical_terms75:
+  organization_id: 1
   chemical_id: '2'
   term: '2012'
 
 
 chemical_terms76:
+  organization_id: 1
   chemical_id: '2'
   term: '2016'
 
 
 chemical_terms77:
+  organization_id: 1
   chemical_id: '5'
   term: '2010'
 
 
 chemical_terms78:
+  organization_id: 1
   chemical_id: '5'
   term: '2011'
 
 
 chemical_terms79:
+  organization_id: 1
   chemical_id: '5'
   term: '2014'
 
 
 chemical_terms80:
+  organization_id: 1
   chemical_id: '5'
   term: '2013'
 
 
 chemical_terms81:
+  organization_id: 1
   chemical_id: '5'
   term: '2015'
 
 
 chemical_terms82:
+  organization_id: 1
   chemical_id: '5'
   term: '2012'
 
 
 chemical_terms83:
+  organization_id: 1
   chemical_id: '5'
   term: '2016'
 
 
 chemical_terms84:
+  organization_id: 1
   chemical_id: '14'
   term: '2010'
 
 
 chemical_terms85:
+  organization_id: 1
   chemical_id: '14'
   term: '2011'
 
 
 chemical_terms86:
+  organization_id: 1
   chemical_id: '14'
   term: '2014'
 
 
 chemical_terms87:
+  organization_id: 1
   chemical_id: '14'
   term: '2013'
 
 
 chemical_terms88:
+  organization_id: 1
   chemical_id: '14'
   term: '2015'
 
 
 chemical_terms89:
+  organization_id: 1
   chemical_id: '14'
   term: '2012'
 
 
 chemical_terms90:
+  organization_id: 1
   chemical_id: '14'
   term: '2016'
 
 
 chemical_terms91:
+  organization_id: 1
   chemical_id: '15'
   term: '2010'
 
 
 chemical_terms92:
+  organization_id: 1
   chemical_id: '15'
   term: '2011'
 
 
 chemical_terms93:
+  organization_id: 1
   chemical_id: '15'
   term: '2014'
 
 
 chemical_terms94:
+  organization_id: 1
   chemical_id: '15'
   term: '2013'
 
 
 chemical_terms95:
+  organization_id: 1
   chemical_id: '15'
   term: '2015'
 
 
 chemical_terms96:
+  organization_id: 1
   chemical_id: '15'
   term: '2012'
 
 
 chemical_terms97:
+  organization_id: 1
   chemical_id: '15'
   term: '2016'
 
 
 chemical_terms98:
+  organization_id: 1
   chemical_id: '16'
   term: '2010'
 
 
 chemical_terms99:
+  organization_id: 1
   chemical_id: '16'
   term: '2011'
 
 
 chemical_terms100:
+  organization_id: 1
   chemical_id: '16'
   term: '2014'
 
 
 chemical_terms101:
+  organization_id: 1
   chemical_id: '16'
   term: '2013'
 
 
 chemical_terms102:
+  organization_id: 1
   chemical_id: '16'
   term: '2015'
 
 
 chemical_terms103:
+  organization_id: 1
   chemical_id: '16'
   term: '2012'
 
 
 chemical_terms104:
+  organization_id: 1
   chemical_id: '16'
   term: '2016'
 
 
 chemical_terms105:
+  organization_id: 1
   chemical_id: '17'
   term: '2010'
 
 
 chemical_terms106:
+  organization_id: 1
   chemical_id: '17'
   term: '2011'
 
 
 chemical_terms107:
+  organization_id: 1
   chemical_id: '17'
   term: '2014'
 
 
 chemical_terms108:
+  organization_id: 1
   chemical_id: '17'
   term: '2013'
 
 
 chemical_terms109:
+  organization_id: 1
   chemical_id: '17'
   term: '2015'
 
 
 chemical_terms110:
+  organization_id: 1
   chemical_id: '17'
   term: '2012'
 
 
 chemical_terms111:
+  organization_id: 1
   chemical_id: '17'
   term: '2016'
 
 
 chemical_term_genka:
+  organization_id: 1
   chemical: chemical_genka
   term: 2017
   price: 600
 
 chemical_term_amistar:
+  organization_id: 1
   chemical: chemical_amistar
   term: 2016
   price: 600

--- a/test/fixtures/chemicals.yml
+++ b/test/fixtures/chemicals.yml
@@ -19,13 +19,20 @@
 #  updated_at                 :datetime
 #  base_unit_id(基本単位)     :integer          default(0), not null
 #  chemical_type_id(薬剤種別) :integer          not null
+#  organization_id(組織)      :bigint           not null
 #
 # Indexes
 #
-#  index_chemicals_on_deleted_at  (deleted_at)
+#  index_chemicals_on_deleted_at       (deleted_at)
+#  index_chemicals_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
 #
 
 chemicals0:
+  organization_id: 1
   id: '1'
   name: キチット（1㎏）
   phonetic: 'きちっと'
@@ -37,6 +44,7 @@ chemicals0:
 
 
 chemicals1:
+  organization_id: 1
   id: '2'
   name: Gオンコル(1kg)
   phonetic: 'Gおんこる'
@@ -48,6 +56,7 @@ chemicals1:
 
 
 chemicals2:
+  organization_id: 1
   id: '3'
   name: セラコートRワン
   phonetic: 'さらこーとRわん'
@@ -59,6 +68,7 @@ chemicals2:
 
 
 chemicals3:
+  organization_id: 1
   id: '4'
   unit: 
   name: 米育ち一発024号
@@ -78,6 +88,7 @@ chemicals3:
 
 
 chemicals4:
+  organization_id: 1
   id: '5'
   name: いずも稲作名人
   phonetic: 'いずもいなさくめいじん'
@@ -94,6 +105,7 @@ chemicals4:
 
 
 chemicals5:
+  organization_id: 1
   id: '6'
   name: オンコル5(3kg)
   phonetic: 'おんこる'
@@ -105,6 +117,7 @@ chemicals5:
 
 
 chemicals6:
+  organization_id: 1
   id: '7'
   name: バッチリ
   phonetic: 'ばっちり'
@@ -116,6 +129,7 @@ chemicals6:
 
 
 chemicals7:
+  organization_id: 1
   id: '8'
   name: 硫安
   phonetic: 'りゅうあん'
@@ -127,6 +141,7 @@ chemicals7:
 
 
 chemicals8:
+  organization_id: 1
   id: '9'
   name: いーね463
   phonetic: 'いーね'
@@ -138,6 +153,7 @@ chemicals8:
 
 
 chemicals9:
+  organization_id: 1
   id: '10'
   name: V550
   phonetic: 'V550'
@@ -149,6 +165,7 @@ chemicals9:
 
 
 chemicals10:
+  organization_id: 1
   id: '11'
   name: V550
   phonetic: 'V550'
@@ -160,6 +177,7 @@ chemicals10:
 
 
 chemicals11:
+  organization_id: 1
   id: '12'
   name: 苗（コシヒカリ）
   phonetic: 'いね'
@@ -171,6 +189,7 @@ chemicals11:
 
 
 chemicals12:
+  organization_id: 1
   id: '13'
   name: サラブレッド（1㎏）
   phonetic: 'さらぶれっど'
@@ -182,6 +201,7 @@ chemicals12:
 
 
 chemicals13:
+  organization_id: 1
   id: '14'
   name: グランドオリゼメート
   phonetic: 'ぐらんどおりぜめーと'
@@ -193,6 +213,7 @@ chemicals13:
 
 
 chemicals14:
+  organization_id: 1
   id: '15'
   name: フルターボ
   phonetic: 'ふるたーぼ'
@@ -204,6 +225,7 @@ chemicals14:
 
 
 chemicals15:
+  organization_id: 1
   id: '16'
   name: オサキニ
   phonetic: 'おさきに'
@@ -215,6 +237,7 @@ chemicals15:
 
 
 chemicals16:
+  organization_id: 1
   id: '17'
   name: ユーコート844
   phonetic: 'ゆーこーと'
@@ -225,6 +248,7 @@ chemicals16:
   deleted_at: 
 
 chemical_genka:
+  organization_id: 1
   name: "原価テスト用ダミー"
   phonetic: 'げんかてすと'
   display_order: 99
@@ -234,6 +258,7 @@ chemical_genka:
   deleted_at: 
 
 chemical_amistar:
+  organization_id: 1
   name: "アミスターダミー"
   phonetic: 'あみすたーだみー'
   display_order: 0

--- a/test/models/chemical_stock_test.rb
+++ b/test/models/chemical_stock_test.rb
@@ -65,6 +65,38 @@ class ChemicalStockTest < ActiveSupport::TestCase
     assert_equal stock6.inventory - stock5.stock, stock6.adjust
   end
 
+  test "在庫がない薬剤でも作業実績から在庫を作成する" do
+    chemical_id = 4
+    work_chemical = work_chemicals(:work_chemical_stock)
+    ChemicalStock.for_organization(1).where(chemical_id: chemical_id).destroy_all
+
+    before_count = ChemicalStock.for_organization(1).where(chemical_id: chemical_id).count
+    ChemicalStock.refresh(1, chemical_id)
+    assert_operator ChemicalStock.for_organization(1).where(chemical_id: chemical_id).count, :>, before_count
+
+    stock = ChemicalStock.for_organization(1).find_by(work_chemical_id: work_chemical.id)
+    assert_not_nil stock
+    assert_equal work_chemical.quantity, stock.using
+    assert_equal work_chemical.work.worked_at, stock.stock_on
+  end
+
+  test "作業実績から作る在庫は他組織の既存行を更新しない" do
+    work_chemical = work_chemicals(:work_chemical_stock)
+    other_stock = chemical_stocks(:stock_for_test)
+    other_stock.update_columns(
+      organization_id: 2,
+      work_chemical_id: work_chemical.id,
+      chemical_id: work_chemical.chemical_id,
+      using: 999
+    )
+
+    ChemicalStock.refresh(1, work_chemical.chemical_id)
+
+    other_stock.reload
+    assert_equal 2, other_stock.organization_id
+    assert_equal 999, other_stock.using
+  end
+
   test "納品" do
     stock_quantity = 4
     stock_for_test = chemical_stocks(:stock_for_test)

--- a/test/models/chemical_stock_test.rb
+++ b/test/models/chemical_stock_test.rb
@@ -15,7 +15,17 @@
 #  updated_at                      :datetime         not null
 #  chemical_id(薬剤)               :integer          not null
 #  chemical_inventory_id(薬剤棚卸) :integer
+#  organization_id(組織)           :bigint           not null
 #  work_chemical_id(薬剤使用)      :integer
+#
+# Indexes
+#
+#  idx_on_organization_id_chemical_id_stock_on_ccf855096c  (organization_id,chemical_id,stock_on)
+#  index_chemical_stocks_on_organization_id                (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
 #
 
 require 'test_helper'

--- a/test/services/lands/chemical_map_service_test.rb
+++ b/test/services/lands/chemical_map_service_test.rb
@@ -30,9 +30,9 @@ class Lands::ChemicalMapServiceTest < ActiveSupport::TestCase
     chemical2 = create_chemical(name: "試験薬剤い", phonetic: "しけんやくざいい")
     chemical3 = create_chemical(name: "試験薬剤う", phonetic: "しけんやくざいう")
 
-    term1 = ChemicalTerm.create!(chemical: chemical1, term: 2015)
-    term2 = ChemicalTerm.create!(chemical: chemical2, term: 2015)
-    term3 = ChemicalTerm.create!(chemical: chemical3, term: 2015)
+    term1 = ChemicalTerm.create!(organization: organizations(:org), chemical: chemical1, term: 2015)
+    term2 = ChemicalTerm.create!(organization: organizations(:org), chemical: chemical2, term: 2015)
+    term3 = ChemicalTerm.create!(organization: organizations(:org), chemical: chemical3, term: 2015)
 
     ChemicalWorkType.create!(chemical_term: term1, work_type: work_types(:work_type_koshi), quantity: 1.0)
     ChemicalWorkType.create!(chemical_term: term2, work_type: work_types(:work_type_koshi), quantity: 0.5)
@@ -86,7 +86,7 @@ class Lands::ChemicalMapServiceTest < ActiveSupport::TestCase
     LandCost.create!(land: land2, work_type: work_types(:work_type_koshi), activated_on: Date.new(2015, 1, 1))
 
     chemical = create_chemical(name: "試験薬剤え", phonetic: "しけんやくざいえ")
-    term = ChemicalTerm.create!(chemical: chemical, term: 2015)
+    term = ChemicalTerm.create!(organization: organizations(:org), chemical: chemical, term: 2015)
     ChemicalWorkType.create!(chemical_term: term, work_type: work_types(:work_type_koshi), quantity: 1.0)
     WorkChemical.create!(work: work, chemical: chemical, quantity: 2.0, chemical_group_no: 1)
 
@@ -142,6 +142,7 @@ class Lands::ChemicalMapServiceTest < ActiveSupport::TestCase
 
   def create_chemical(name:, phonetic:)
     Chemical.create!(
+      organization: organizations(:org),
       chemical_type: chemical_types(:chemical_types0),
       name: name,
       phonetic: phonetic,


### PR DESCRIPTION
実装しました。農薬系4テーブルに `organization_id` を追加し、`chemicals` / `chemical_terms` / `chemical_inventories` / `chemical_stocks` を `current_organization` で絞るようにしています。

主な対応は以下です。

- 新規 migration 追加: [20260511090000_add_organization_to_chemical_tables.rb](/farm2/db/migrate/20260511090000_add_organization_to_chemical_tables.rb)
- `default: 3` は使わず、既存データを先頭 organization で backfill した後、DB定義は `null: false` / デフォルトなし
- `chemical_terms` の unique index を `organization_id, chemical_id, term` に変更
- 在庫再計算 `ChemicalStock.refresh` を組織単位に修正
- 棚卸・納品・在庫・農薬管理画面の `find` / 一覧 / 作成を組織スコープ化
- `chemical_work_types` は列追加せず、`chemical_terms.organization_id` 経由で組織条件を追加
- fixtures と関連テストを `organization_id` 対応
