### PR TITLE
#901 phase.6

### DIFF
--- a/app/controllers/gaps/monthly_reports_controller.rb
+++ b/app/controllers/gaps/monthly_reports_controller.rb
@@ -13,7 +13,7 @@ class Gaps::MonthlyReportsController < GapsController
   def months
     @months = []
     Work.for_organization(current_organization).where(work_type_id: params[:id], term: current_term)
-      .select("TO_CHAR(worked_at, 'YYYY/MM') AS yyyymm").distinct("yyyymm").order(:yyyymm).each do |work|
+      .select("TO_CHAR(worked_at, 'YYYY/MM') AS yyyymm").distinct("yyyymm").order('yyyymm').each do |work|
       yyyy, mm = work.yyyymm.split('/')
       @months << ["#{yyyy}年 #{mm}月", Date.new(yyyy.to_i, mm.to_i, 1)]
     end

--- a/app/controllers/gaps/monthly_reports_controller.rb
+++ b/app/controllers/gaps/monthly_reports_controller.rb
@@ -1,12 +1,19 @@
 class Gaps::MonthlyReportsController < GapsController
   def index
-    @works = WorkDecorator.decorate_collection(Work.monthly_reports(params[:work_type_id], params[:worked_at].to_date)) if params[:work_type_id].present? && params[:worked_at].present?
+    if params[:work_type_id].present? && params[:worked_at].present?
+      works = Work.monthly_reports(
+        params.expect(:work_type_id),
+        params.expect(:worked_at).to_date,
+        current_organization
+      )
+      @works = WorkDecorator.decorate_collection(works)
+    end
   end
 
   def months
     @months = []
-    Work.where(work_type_id: params[:id], term: current_term)
-      .select("TO_CHAR(worked_at, 'YYYY/MM') AS yyyymm").distinct("yyyymm").order("yyyymm").each do |work|
+    Work.for_organization(current_organization).where(work_type_id: params[:id], term: current_term)
+      .select("TO_CHAR(worked_at, 'YYYY/MM') AS yyyymm").distinct("yyyymm").order(:yyyymm).each do |work|
       yyyy, mm = work.yyyymm.split('/')
       @months << ["#{yyyy}年 #{mm}月", Date.new(yyyy.to_i, mm.to_i, 1)]
     end

--- a/app/controllers/personal_informations/maps_controller.rb
+++ b/app/controllers/personal_informations/maps_controller.rb
@@ -3,7 +3,8 @@ class PersonalInformations::MapsController < PersonalInformationsController
 
   def index
     @target = Time.zone.today
-    @costs = LandCost.usual(Land.regionable.expiry(@target), @target).includes(land: [:owner, { manager: :holder }], work_type: [])
+    lands = Land.for_organization(current_organization).regionable.expiry(@target)
+    @costs = LandCost.usual(lands, @target).includes(land: [:owner, { manager: :holder }], work_type: [])
     @work_types = WorkType.land.by_term(current_organization.get_term(@target))
   end
 end

--- a/app/controllers/statistics/work_days_controller.rb
+++ b/app/controllers/statistics/work_days_controller.rb
@@ -2,7 +2,7 @@ class Statistics::WorkDaysController < ApplicationController
   include PermitManager
 
   def index
-    @homes = Home.usual.for_fee
-    @work_days = Work.work_days
+    @homes = Home.for_organization(current_organization).usual.for_fee
+    @work_days = Work.work_days(current_organization)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,12 +5,13 @@ class UsersController < ApplicationController
   before_action :permit_self, only: [:edit, :update]
 
   def index
-    @workers = WorkerDecorator.decorate_collection(Worker.includes(:user).usual.page(params[:page]))
+    workers = Worker.for_organization(current_organization).includes(:user).usual.page(params[:page])
+    @workers = WorkerDecorator.decorate_collection(workers)
   end
 
   def new
     @user = User.new
-    @user.worker_id = params[:worker_id]
+    @user.worker_id = Worker.for_organization(current_organization).find_by(id: params[:worker_id])&.id
   end
 
   def edit; end
@@ -46,16 +47,25 @@ class UsersController < ApplicationController
   private
 
   def set_return_to
-    fallback = (action_name.in?(["edit", "update"]) && @user&.id == current_user.id) ? menu_index_path : users_path
-    @return_to = safe_return_to_path(params[:return_to], fallback: fallback, allowed_paths: [users_path, menu_index_path])
+    fallback = action_name.in?(["edit", "update"]) && @user&.id == current_user.id ? menu_index_path : users_path
+    @return_to = safe_return_to_path(
+      params[:return_to],
+      fallback: fallback,
+      allowed_paths: [users_path, menu_index_path]
+    )
   end
 
   def set_user
-    @user = User.find(params[:id])
+    @user = User.find_by(id: params[:id], organization_id: current_organization.id)
+    to_error_path unless @user
   end
 
   def user_params
-    params.expect(user: [:login_name, :password, :password_confirmation, :worker_id])
+    permitted = params.expect(user: [:login_name, :password, :password_confirmation, :worker_id])
+    if permitted[:worker_id].present?
+      permitted[:worker_id] = Worker.for_organization(current_organization).find_by(id: permitted[:worker_id])&.id
+    end
+    permitted
   end
 
   def permit_self

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -63,7 +63,12 @@ class UsersController < ApplicationController
   def user_params
     permitted = params.expect(user: [:login_name, :password, :password_confirmation, :worker_id])
     if permitted[:worker_id].present?
-      permitted[:worker_id] = Worker.for_organization(current_organization).find_by(id: permitted[:worker_id])&.id
+      worker = Worker.for_organization(current_organization).find_by(id: permitted[:worker_id])
+      if worker
+        permitted[:worker_id] = worker.id
+      else
+        permitted.delete(:worker_id)
+      end
     end
     permitted
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -202,10 +202,11 @@ SQL
       )
   }
 
-  scope :monthly_reports, lambda { |work_type_id, worked_at|
-    where(work_type_id: work_type_id)
+  scope :monthly_reports, lambda { |work_type_id, worked_at, organization = nil|
+    base = where(work_type_id: work_type_id)
       .where(worked_at: Date.new(worked_at.year, worked_at.month, 1)..Date.new(worked_at.year, worked_at.month, -1))
       .order(worked_at: :ASC, start_at: :ASC, id: :ASC)
+    organization ? base.for_organization(organization) : base
   }
 
   scope :landable, lambda {
@@ -498,8 +499,10 @@ SQL
     results
   end
 
-  def self.work_days
-    Work.joins(:workers).group(Work.arel_table[:term], Worker.arel_table[:home_id])
+  def self.work_days(organization = nil)
+    base = Work.joins(:workers)
+    base = base.for_organization(organization) if organization
+    base.group(Work.arel_table[:term], Worker.arel_table[:home_id])
       .distinct.count(Work.arel_table[:worked_at])
   end
 

--- a/test/controllers/gaps/monthly_reports_controller_test.rb
+++ b/test/controllers/gaps/monthly_reports_controller_test.rb
@@ -9,4 +9,45 @@ class Gaps::MonthlyReportsControllerTest < ActionDispatch::IntegrationTest
     get gaps_monthly_reports_path
     assert_response :success
   end
+
+  test "GAP作業月毎記録表に他組織の作業を表示しない" do
+    other_work = create_other_organization_monthly_report_work
+
+    get gaps_monthly_reports_path, params: { work_type_id: other_work.work_type_id, worked_at: other_work.worked_at }
+
+    assert_response :success
+    assert_no_match other_work.name, @response.body
+  end
+
+  test "GAP作業月毎記録表の年月候補に他組織の作業月を表示しない" do
+    other_work = create_other_organization_monthly_report_work
+
+    get months_gaps_monthly_report_path(other_work.work_type_id)
+
+    assert_response :success
+    assert_no_match "2015年 04月", @response.body
+  end
+
+  private
+
+  def create_other_organization_monthly_report_work
+    work_type = WorkType.create!(
+      genre: work_genres(:genre_rice),
+      name: "他組織月報",
+      display_order: 999,
+      land_flag: true
+    )
+    Work.create!(
+      organization: organizations(:org2),
+      term: 2015,
+      worked_at: Date.new(2015, 4, 1),
+      weather_id: :sunny,
+      work_type: work_type,
+      work_kind: work_kinds(:work_kind_taue),
+      name: "他組織月報作業",
+      start_at: "08:00",
+      end_at: "12:00",
+      created_by: workers(:worker_other_org).id
+    )
+  end
 end

--- a/test/controllers/personal_informations/maps_controller_test.rb
+++ b/test/controllers/personal_informations/maps_controller_test.rb
@@ -9,4 +9,17 @@ class PersonalInformations::MapsControllerTest < ActionDispatch::IntegrationTest
     get personal_information_maps_path(personal_information_token: @user.token)
     assert_response :success
   end
+
+  test "地図に他組織の土地を表示しない" do
+    other_land = lands(:land_other_org)
+    other_land.update!(region: "((35.474177,133.047340), (35.472866,133.047340), (35.472648,133.049056))")
+    LandCost.find_or_create_by!(land: other_land, activated_on: Date.new(1900, 1, 1)) do |cost|
+      cost.work_type = work_types(:work_type_koshi)
+    end
+
+    get personal_information_maps_path(personal_information_token: @user.token)
+
+    assert_response :success
+    assert_select "input#land_#{other_land.id}", count: 0
+  end
 end

--- a/test/controllers/statistics/work_days_controller_test.rb
+++ b/test/controllers/statistics/work_days_controller_test.rb
@@ -9,4 +9,11 @@ class Statistics::WorkDaysControllerTest < ActionDispatch::IntegrationTest
     get statistics_work_days_path
     assert_response :success
   end
+
+  test "世帯別作業一覧に他組織の世帯を表示しない" do
+    get statistics_work_days_path
+
+    assert_response :success
+    assert_no_match homes(:home_other_org).name, @response.body
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -63,10 +63,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "ユーザ変更(実行)" do
-    patch user_path(@user), params: { user: { login_name: 'updateuser', password: "AAAA", password_confirmation: "AAA" } }
+    patch user_path(@user),
+          params: { user: { login_name: 'updateuser', password: "AAAA", password_confirmation: "AAA" } }
     assert_response :unprocessable_content
 
-    patch user_path(@user), params: { user: { login_name: 'updateuser', password: "AAAA", password_confirmation: "AAAA" } }
+    patch user_path(@user),
+          params: { user: { login_name: 'updateuser', password: "AAAA", password_confirmation: "AAAA" } }
     assert_redirected_to menu_index_path
 
     @user.reload
@@ -76,7 +78,11 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   test "ユーザ変更(実行)(元のページへ戻る)" do
     user = users(:user_manager)
 
-    patch user_path(user), params: { user: { login_name: 'returnuser', password: "AAAA", password_confirmation: "AAAA" }, return_to: users_path(page: 2) }
+    patch user_path(user),
+          params: {
+            user: { login_name: 'returnuser', password: "AAAA", password_confirmation: "AAAA" },
+            return_to: users_path(page: 2)
+          }
     assert_redirected_to users_path(page: 2)
 
     user.reload
@@ -86,7 +92,11 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   test "ユーザ変更(実行)(不正な戻り先は一覧へ戻る)" do
     user = users(:user_manager)
 
-    patch user_path(user), params: { user: { login_name: 'safeuser', password: "AAAA", password_confirmation: "AAAA" }, return_to: "https://example.com/" }
+    patch user_path(user),
+          params: {
+            user: { login_name: 'safeuser', password: "AAAA", password_confirmation: "AAAA" },
+            return_to: "https://example.com/"
+          }
     assert_redirected_to users_path
 
     user.reload
@@ -109,5 +119,19 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to users_path(page: 2)
     assert_nil User.find_by(id: user.id)
+  end
+  test "ユーザ一覧に他組織の作業者を表示しない" do
+    get users_path
+
+    assert_response :success
+    assert_no_match workers(:worker_other_org).name, @response.body
+    assert_no_match homes(:home_other_org).name, @response.body
+    assert_no_match users(:user_admin_org2).login_name, @response.body
+  end
+
+  test "他組織のユーザは直接指定しても変更できない" do
+    get edit_user_path(users(:user_admin_org2))
+
+    assert_response :service_unavailable
   end
 end


### PR DESCRIPTION
優先順はこうです。

1. `users_controller`
   他組織ユーザ/作業者が見えたり触れたりする可能性があるので、最優先です。

2. `personal_informations/maps_controller`
   個人情報側の地図で `Land` が組織スコープなしなので、他組織の土地が混ざるリスクがあります。

3. `statistics/work_days_controller`
   `Home` / `Work` 集計が組織スコープなしなので、統計値が混ざる可能性があります。

4. `gaps/monthly_reports_controller`
   明らかな `Work.where(...)` 直書きがあり、組織スコープ追加で直せそうなら一緒に対応する、くらいの位置づけです。

この範囲なら、DB migration なしで進められて、影響箇所も限定的です。  
リリース後の確認も「組織1で従来通り表示・更新できる」「組織2 fixture 相当のデータが混ざらない」の観点で見やすいです。