### PR TITLE
#1033 ブルートフォース対策

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,7 +14,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by(login_name: params[:login_name].downcase)
+    user = User.find_by(login_name: params[:login_name].to_s.downcase)
     if user&.login_locked?
       render partial: 'flash', content_type: 'text/vnd.turbo-stream.html', locals: { message: I18n.t("session.locked") }
     elsif user&.authenticate(params[:password])

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,17 +15,19 @@ class SessionsController < ApplicationController
 
   def create
     user = User.find_by(login_name: params[:login_name].to_s.downcase)
+    user&.unlock_if_expired!
+
     if user&.login_locked?
-      render partial: 'flash', content_type: 'text/vnd.turbo-stream.html', locals: { message: I18n.t("session.locked") }
+      Rails.logger.warn("Locked login attempt for user_id=#{user.id}")
+      render_login_error
     elsif user&.authenticate(params[:password])
       user.reset_login_failures!
       log_in(user)
       redirect_to prefixed_path(menu_index_path)
     else
       user&.register_failed_login!
-
-      message = user&.login_locked? ? I18n.t("session.locked") : I18n.t("session.login_error")
-      render partial: 'flash', content_type: 'text/vnd.turbo-stream.html', locals: { message: message }
+      Rails.logger.warn("User locked after failed login attempts for user_id=#{user.id}") if user&.login_locked?
+      render_login_error
     end
   end
 
@@ -33,5 +35,9 @@ class SessionsController < ApplicationController
 
   def check_login_ip_access!
     require_ip_whitelist!
+  end
+
+  def render_login_error
+    render partial: 'flash', content_type: 'text/vnd.turbo-stream.html', locals: { message: I18n.t("session.login_error") }
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,11 +15,17 @@ class SessionsController < ApplicationController
 
   def create
     user = User.find_by(login_name: params[:login_name].downcase)
-    if user&.authenticate(params[:password])
+    if user&.login_locked?
+      render partial: 'flash', content_type: 'text/vnd.turbo-stream.html', locals: { message: I18n.t("session.locked") }
+    elsif user&.authenticate(params[:password])
+      user.reset_login_failures!
       log_in(user)
       redirect_to prefixed_path(menu_index_path)
     else
-      render partial: 'flash', content_type: 'text/vnd.turbo-stream.html', locals: { message: I18n.t("session.login_error") }
+      user&.register_failed_login!
+
+      message = user&.login_locked? ? I18n.t("session.locked") : I18n.t("session.login_error")
+      render partial: 'flash', content_type: 'text/vnd.turbo-stream.html', locals: { message: message }
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,11 +110,18 @@ class User < ApplicationRecord
   end
 
   def unlock_if_expired!
-    return false if locked_at.blank?
-    return false if login_locked?
+    unlocked = false
 
-    reset_login_failures!
-    true
+    with_lock do
+      reload
+      next if locked_at.blank?
+      next if login_locked?
+
+      reset_login_failures!
+      unlocked = true
+    end
+
+    unlocked
   end
 
   def register_failed_login!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@
 #
 #  id(利用者マスタ)                                         :integer          not null, primary key
 #  calendar_term(期(カレンダー))                            :integer          default(2018), not null
+#  failed_login_attempts(ログイン失敗回数)                  :integer          default(0), not null
+#  locked_at(ログインロック日時)                            :datetime
 #  login_name(ログイン名)                                   :string(12)       not null
 #  mail(メールアドレス)                                     :string(255)      default(""), not null
 #  mail_confirmation_expired_at(メールアドレス確認有効期限) :datetime
@@ -36,6 +38,9 @@
 #
 require "rotp"
 class User < ApplicationRecord
+  MAX_FAILED_LOGIN_ATTEMPTS = 5
+  LOGIN_LOCKOUT_DURATION = 15.minutes
+
   before_create :set_token
   before_update :clear_mail_fields, if: -> { mail_changed? && mail.present? }
   after_update :set_pc_mail, if: -> { saved_change_to_mail_confirmed_at? && mail_confirmed_at.present? }
@@ -98,6 +103,27 @@ class User < ApplicationRecord
 
   def linable?
     line_id.present?
+  end
+
+  def login_locked?
+    return false if locked_at.blank?
+
+    return true if locked_at > LOGIN_LOCKOUT_DURATION.ago
+
+    reset_login_failures!
+    false
+  end
+
+  def register_failed_login!
+    with_lock do
+      self.failed_login_attempts += 1
+      self.locked_at = Time.current if failed_login_attempts >= MAX_FAILED_LOGIN_ATTEMPTS
+      save!(validate: false)
+    end
+  end
+
+  def reset_login_failures!
+    update_columns(failed_login_attempts: 0, locked_at: nil, updated_at: Time.current)
   end
 
   def push_notification_granted?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,9 +119,18 @@ class User < ApplicationRecord
 
   def register_failed_login!
     with_lock do
-      self.failed_login_attempts += 1
-      self.locked_at = Time.current if failed_login_attempts >= MAX_FAILED_LOGIN_ATTEMPTS
-      save!(validate: false)
+      now = Time.current
+      new_failed_login_attempts = failed_login_attempts.to_i + 1
+      new_locked_at = new_failed_login_attempts >= MAX_FAILED_LOGIN_ATTEMPTS ? now : locked_at
+
+      update_columns(
+        failed_login_attempts: new_failed_login_attempts,
+        locked_at: new_locked_at,
+        updated_at: now
+      )
+
+      self.failed_login_attempts = new_failed_login_attempts
+      self.locked_at = new_locked_at
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,12 +106,15 @@ class User < ApplicationRecord
   end
 
   def login_locked?
-    return false if locked_at.blank?
+    locked_at.present? && locked_at > LOGIN_LOCKOUT_DURATION.ago
+  end
 
-    return true if locked_at > LOGIN_LOCKOUT_DURATION.ago
+  def unlock_if_expired!
+    return false if locked_at.blank?
+    return false if login_locked?
 
     reset_login_failures!
-    false
+    true
   end
 
   def register_failed_login!

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -21,6 +21,7 @@ ja:
 
   session:
     login_error: "IDまたはpasswordが間違っています。"
+    locked: "ログインに複数回失敗したため、一時的にロックされています。しばらく待ってから再度お試しください。"
 
   line_hook:
     already_linked: "あなたのユーザ情報は既に登録済です。"

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -21,7 +21,6 @@ ja:
 
   session:
     login_error: "IDまたはpasswordが間違っています。"
-    locked: "ログインに複数回失敗したため、一時的にロックされています。しばらく待ってから再度お試しください。"
 
   line_hook:
     already_linked: "あなたのユーザ情報は既に登録済です。"

--- a/db/migrate/20260525090000_add_login_lock_fields_to_users.rb
+++ b/db/migrate/20260525090000_add_login_lock_fields_to_users.rb
@@ -1,0 +1,6 @@
+class AddLoginLockFieldsToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :failed_login_attempts, :integer, default: 0, null: false, comment: "ログイン失敗回数"
+    add_column :users, :locked_at, :datetime, comment: "ログインロック日時"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_16_144004) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_25_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgroonga"
@@ -1037,7 +1037,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_16_144004) do
   create_table "users", id: { type: :serial, comment: "利用者マスタ" }, comment: "利用者マスタ", force: :cascade do |t|
     t.integer "calendar_term", default: 2018, null: false, comment: "期(カレンダー)"
     t.datetime "created_at", precision: nil, null: false
+    t.integer "failed_login_attempts", default: 0, null: false, comment: "ログイン失敗回数"
     t.string "line_id", limit: 50, default: "", null: false
+    t.datetime "locked_at", comment: "ログインロック日時"
     t.string "login_name", limit: 12, null: false, comment: "ログイン名"
     t.string "mail", limit: 255, default: "", null: false, comment: "メールアドレス"
     t.datetime "mail_confirmation_expired_at", comment: "メールアドレス確認有効期限"

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -49,7 +49,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     post sessions_path, params: { login_name: @user.login_name, password: "hogehoge" }
 
-    assert_select 'div.alert.alert-danger', I18n.t("session.locked")
+    assert_select 'div.alert.alert-danger', I18n.t("session.login_error")
     assert_nil session[:user_id]
     assert_equal User::MAX_FAILED_LOGIN_ATTEMPTS, @user.reload.failed_login_attempts
     assert_not_nil @user.locked_at
@@ -60,7 +60,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     post sessions_path, params: { login_name: @user.login_name, password: "password" }
 
-    assert_select 'div.alert.alert-danger', I18n.t("session.locked")
+    assert_select 'div.alert.alert-danger', I18n.t("session.login_error")
     assert_nil session[:user_id]
     assert_equal User::MAX_FAILED_LOGIN_ATTEMPTS, @user.reload.failed_login_attempts
   end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -24,13 +24,59 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     post sessions_path, params: { login_name: @user.login_name, password: "hogehoge" }
     assert_select 'div.alert.alert-danger', I18n.t("session.login_error")
     assert_nil session[:user_id]
+    assert_equal 1, @user.reload.failed_login_attempts
   end
 
   test "ログイン実行(成功)" do
+    @user.update!(failed_login_attempts: 2, locked_at: nil)
+
     post sessions_path, params: { login_name: @user.login_name, password: "password" }
     assert_redirected_to menu_index_path
     assert_equal @user.id, session[:user_id]
     assert_equal "PC", session[:access_target]
+    assert_equal 0, @user.reload.failed_login_attempts
+    assert_nil @user.locked_at
+  end
+
+  test "ログイン実行(閾値到達でロック)" do
+    (User::MAX_FAILED_LOGIN_ATTEMPTS - 1).times do
+      post sessions_path, params: { login_name: @user.login_name, password: "hogehoge" }
+    end
+
+    @user.reload
+    assert_equal User::MAX_FAILED_LOGIN_ATTEMPTS - 1, @user.failed_login_attempts
+    assert_nil @user.locked_at
+
+    post sessions_path, params: { login_name: @user.login_name, password: "hogehoge" }
+
+    assert_select 'div.alert.alert-danger', I18n.t("session.locked")
+    assert_nil session[:user_id]
+    assert_equal User::MAX_FAILED_LOGIN_ATTEMPTS, @user.reload.failed_login_attempts
+    assert_not_nil @user.locked_at
+  end
+
+  test "ログイン実行(ロック中)" do
+    @user.update!(failed_login_attempts: User::MAX_FAILED_LOGIN_ATTEMPTS, locked_at: Time.current)
+
+    post sessions_path, params: { login_name: @user.login_name, password: "password" }
+
+    assert_select 'div.alert.alert-danger', I18n.t("session.locked")
+    assert_nil session[:user_id]
+    assert_equal User::MAX_FAILED_LOGIN_ATTEMPTS, @user.reload.failed_login_attempts
+  end
+
+  test "ログイン実行(ロック期限切れ後は再ログインできる)" do
+    @user.update!(
+      failed_login_attempts: User::MAX_FAILED_LOGIN_ATTEMPTS,
+      locked_at: (User::LOGIN_LOCKOUT_DURATION + 1.minute).ago
+    )
+
+    post sessions_path, params: { login_name: @user.login_name, password: "password" }
+
+    assert_redirected_to menu_index_path
+    assert_equal @user.id, session[:user_id]
+    assert_equal 0, @user.reload.failed_login_attempts
+    assert_nil @user.locked_at
   end
 
   test "ログアウト" do

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,6 +4,8 @@
 #
 #  id(利用者マスタ)                                         :integer          not null, primary key
 #  calendar_term(期(カレンダー))                            :integer          default(2018), not null
+#  failed_login_attempts(ログイン失敗回数)                  :integer          default(0), not null
+#  locked_at(ログインロック日時)                            :datetime
 #  login_name(ログイン名)                                   :string(12)       not null
 #  mail(メールアドレス)                                     :string(255)      default(""), not null
 #  mail_confirmation_expired_at(メールアドレス確認有効期限) :datetime

--- a/test/models/machine_test.rb
+++ b/test/models/machine_test.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: machines(機械マスタ)
+#
+#  id(機械マスタ)                    :integer          not null, primary key
+#  deleted_at                        :datetime
+#  diesel_flag(ディーゼル)           :boolean          default(FALSE), not null
+#  display_order(表示順)             :integer          not null
+#  name(機械名称)                    :string(40)       not null
+#  number(番号)                      :integer
+#  validity_end_at(稼動終了(予定)日) :date
+#  validity_start_at(稼動開始日)     :date
+#  created_at                        :datetime
+#  updated_at                        :datetime
+#  home_id(所有者)                   :integer          default(0), not null
+#  machine_type_id(機械種別)         :integer          default(0), not null
+#
 require "test_helper"
 
 class MachineTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,6 +4,8 @@
 #
 #  id(利用者マスタ)                                         :integer          not null, primary key
 #  calendar_term(期(カレンダー))                            :integer          default(2018), not null
+#  failed_login_attempts(ログイン失敗回数)                  :integer          default(0), not null
+#  locked_at(ログインロック日時)                            :datetime
 #  login_name(ログイン名)                                   :string(12)       not null
 #  mail(メールアドレス)                                     :string(255)      default(""), not null
 #  mail_confirmation_expired_at(メールアドレス確認有効期限) :datetime
@@ -143,6 +145,42 @@ class UserTest < ActiveSupport::TestCase
     assert @checker.checkable?
     assert_not @user.checkable?
     assert_not @visitor.checkable?
+  end
+
+  test "ログイン失敗回数が閾値未満ならロックしない" do
+    assert_changes -> { @user.reload.failed_login_attempts }, from: 0, to: 1 do
+      @user.register_failed_login!
+    end
+    assert_nil @user.reload.locked_at
+    assert_not @user.login_locked?
+  end
+
+  test "ログイン失敗回数が閾値に達するとロックする" do
+    (User::MAX_FAILED_LOGIN_ATTEMPTS - 1).times { @user.register_failed_login! }
+
+    assert_changes -> { @user.reload.locked_at.present? }, from: false, to: true do
+      @user.register_failed_login!
+    end
+    assert_equal User::MAX_FAILED_LOGIN_ATTEMPTS, @user.reload.failed_login_attempts
+    assert @user.login_locked?
+  end
+
+  test "ロック期限切れなら自動解除される" do
+    @user.update!(failed_login_attempts: User::MAX_FAILED_LOGIN_ATTEMPTS, locked_at: (User::LOGIN_LOCKOUT_DURATION + 1.minute).ago)
+
+    assert_changes -> { @user.reload.failed_login_attempts }, from: User::MAX_FAILED_LOGIN_ATTEMPTS, to: 0 do
+      assert_not @user.login_locked?
+    end
+    assert_nil @user.reload.locked_at
+  end
+
+  test "ログイン成功でロック情報をリセットする" do
+    @user.update!(failed_login_attempts: 3, locked_at: Time.current)
+
+    @user.reset_login_failures!
+
+    assert_equal 0, @user.reload.failed_login_attempts
+    assert_nil @user.locked_at
   end
 
   test "TOTP対応(フラグ設定)" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -169,9 +169,10 @@ class UserTest < ActiveSupport::TestCase
     @user.update!(failed_login_attempts: User::MAX_FAILED_LOGIN_ATTEMPTS, locked_at: (User::LOGIN_LOCKOUT_DURATION + 1.minute).ago)
 
     assert_changes -> { @user.reload.failed_login_attempts }, from: User::MAX_FAILED_LOGIN_ATTEMPTS, to: 0 do
-      assert_not @user.login_locked?
+      assert @user.unlock_if_expired!
     end
     assert_nil @user.reload.locked_at
+    assert_not @user.reload.login_locked?
   end
 
   test "ログイン成功でロック情報をリセットする" do


### PR DESCRIPTION
`失敗回数 + 短時間ロック + 自動解除` を実装する。完全ロックアウトやブラックリスト登録は「故意に他人をロックアウト」する可能性から、実装対象外とする。

- `users` に `failed_login_attempts`, `locked_at` を追加
- ログイン失敗で回数加算、例えば `5回失敗で15分ロック`
- 成功時に回数リセット
- エラーメッセージは今のように汎用のまま維持
