### PR TITLE
#901 phase.7 by codex

### DIFF
--- a/app/controllers/lands/chemicals_controller.rb
+++ b/app/controllers/lands/chemicals_controller.rb
@@ -7,11 +7,12 @@ class Lands::ChemicalsController < ApplicationController
     @chemical_types = ChemicalType.usual.where(id: current_organization.rice_planting.chemical_types.select(:id))
     @selected_chemical_type_id = selected_chemical_type_id
     @land_chemical_summaries = Lands::ChemicalMapService.call(
+      organization: current_organization,
       term: current_term,
       work_kind_id: current_organization.rice_planting_id,
       chemical_type_id: @selected_chemical_type_id
     )
-    @lands = Land.regionable
+    @lands = Land.for_organization(current_organization).regionable
       .includes(:owner)
       .where(id: target_land_ids)
       .usual_order
@@ -21,7 +22,13 @@ class Lands::ChemicalsController < ApplicationController
 
   def target_land_ids
     WorkLand.joins(:work)
-      .where(works: { term: current_term, work_kind_id: current_organization.rice_planting_id })
+      .where(
+        works: {
+          organization_id: current_organization.id,
+          term: current_term,
+          work_kind_id: current_organization.rice_planting_id
+        }
+      )
       .select(:land_id)
       .distinct
   end

--- a/app/controllers/plans/lands_controller.rb
+++ b/app/controllers/plans/lands_controller.rb
@@ -23,7 +23,7 @@ class Plans::LandsController < PlansController
   end
 
   def destroy
-    PlanLand.clear_all(current_user.id, plan_term, current_date)
+    PlanLand.clear_all(current_user.id, plan_term, current_date, current_organization)
     redirect_to new_plans_land_path(mode: params[:mode]), status: :see_other
   end
 

--- a/app/controllers/tablets/lands/chemicals_controller.rb
+++ b/app/controllers/tablets/lands/chemicals_controller.rb
@@ -1,16 +1,18 @@
 class Tablets::Lands::ChemicalsController < TabletsController
   include PermitUser
+
   helper GmapHelper
 
   def index
     @chemical_types = ChemicalType.usual.where(id: current_organization.rice_planting.chemical_types.select(:id))
     @selected_chemical_type_id = selected_chemical_type_id
     @land_chemical_summaries = Lands::ChemicalMapService.call(
+      organization: current_organization,
       term: current_term,
       work_kind_id: current_organization.rice_planting_id,
       chemical_type_id: @selected_chemical_type_id
     )
-    @lands = Land.regionable
+    @lands = Land.for_organization(current_organization).regionable
       .includes(:owner)
       .where(id: target_land_ids)
       .usual_order
@@ -20,7 +22,13 @@ class Tablets::Lands::ChemicalsController < TabletsController
 
   def target_land_ids
     WorkLand.joins(:work)
-      .where(works: { term: current_term, work_kind_id: current_organization.rice_planting_id })
+      .where(
+        works: {
+          organization_id: current_organization.id,
+          term: current_term,
+          work_kind_id: current_organization.rice_planting_id
+        }
+      )
       .select(:land_id)
       .distinct
   end

--- a/app/controllers/tablets/maps_controller.rb
+++ b/app/controllers/tablets/maps_controller.rb
@@ -3,6 +3,6 @@ class Tablets::MapsController < TabletsController
 
   def index
     @target = Time.zone.today
-    @lands = Land.regionable.expiry(@target).includes(:owner)
+    @lands = Land.for_organization(current_organization).regionable.expiry(@target).includes(:owner)
   end
 end

--- a/app/models/plan_land.rb
+++ b/app/models/plan_land.rb
@@ -28,9 +28,9 @@ class PlanLand < ApplicationRecord
     end
   end
 
-  def self.clear_all(user_id, term, target)
+  def self.clear_all(user_id, term, target, organization)
     PlanLand.where(user_id: user_id, term: term).delete_all
-    Land.regionable.expiry(target).each do |land|
+    Land.for_organization(organization).regionable.expiry(target).each do |land|
       land_cost = land.cost(target)
       PlanLand.create(user_id: user_id, term: term, land_id: land.id, work_type_id: land_cost.work_type_id) if land_cost
     end

--- a/app/services/lands/chemical_map_service.rb
+++ b/app/services/lands/chemical_map_service.rb
@@ -19,11 +19,12 @@ class Lands::ChemicalMapService
     under_50: "#003a8c"
   }.freeze
 
-  def self.call(term:, work_kind_id:, chemical_type_id:)
-    new(term: term, work_kind_id: work_kind_id, chemical_type_id: chemical_type_id).call
+  def self.call(organization:, term:, work_kind_id:, chemical_type_id:)
+    new(organization: organization, term: term, work_kind_id: work_kind_id, chemical_type_id: chemical_type_id).call
   end
 
-  def initialize(term:, work_kind_id:, chemical_type_id:)
+  def initialize(organization:, term:, work_kind_id:, chemical_type_id:)
+    @organization = organization
     @term = term
     @work_kind_id = work_kind_id
     @chemical_type_id = chemical_type_id
@@ -46,12 +47,12 @@ class Lands::ChemicalMapService
   private
 
   def works
-    @works ||= Work.where(term: @term, work_kind_id: @work_kind_id)
+    @works ||= Work.for_organization(@organization).where(term: @term, work_kind_id: @work_kind_id)
       .includes(work_lands: :land, work_chemicals: :chemical)
   end
 
   def chemical_terms_by_chemical_id
-    @chemical_terms_by_chemical_id ||= ChemicalTerm.joins(:chemical)
+    @chemical_terms_by_chemical_id ||= ChemicalTerm.for_organization(@organization).joins(:chemical)
       .where(term: @term, chemicals: { chemical_type_id: @chemical_type_id })
       .includes(:chemical, :chemical_work_types)
       .index_by(&:chemical_id)

--- a/test/controllers/lands/chemicals_controller_test.rb
+++ b/test/controllers/lands/chemicals_controller_test.rb
@@ -86,4 +86,17 @@ class Lands::ChemicalsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type=hidden][name=regions][data-id='#{map_land.id}'][data-actual]", 1
     assert_select "input[type=hidden][name=regions][data-id='#{excluded_land.id}']", 0
   end
+
+  test "農薬散布地図に他組織の土地を表示しない" do
+    other_land = lands(:land_other_org)
+    other_land.update!(region: "((35.474177,133.047340), (35.472866,133.047340), (35.472648,133.049056))")
+    other_work = works(:work_other_org)
+    other_work.update!(work_kind: work_kinds(:work_kind_taue))
+    WorkLand.create!(work: other_work, land: other_land, work_type_id: work_types(:work_type_koshi).id)
+
+    get lands_chemicals_path
+
+    assert_response :success
+    assert_select "input[type=hidden][name=regions][data-id='#{other_land.id}']", 0
+  end
 end

--- a/test/controllers/plans/lands_controller_test.rb
+++ b/test/controllers/plans/lands_controller_test.rb
@@ -55,4 +55,15 @@ class Plans::LandsControllerTest < ActionDispatch::IntegrationTest
     delete plans_land_path(mode: @mode, id: 0)
     assert_redirected_to new_plans_land_path(mode: @mode)
   end
+
+  test "作付計画の初期化で他組織の土地を登録しない" do
+    other_land = lands(:land_other_org)
+    other_land.update!(region: "((35.474177,133.047340), (35.472866,133.047340), (35.472648,133.049056))")
+    LandCost.create!(land: other_land, work_type: work_types(:work_type_koshi), activated_on: Date.new(1900, 1, 1))
+
+    delete plans_land_path(mode: @mode, id: 0)
+
+    term = @user.organization.get_term(Time.zone.today.next_year)
+    assert_nil PlanLand.find_by(term: term, land_id: other_land.id, user_id: @user.id)
+  end
 end

--- a/test/controllers/tablets/lands/chemicals_controller_test.rb
+++ b/test/controllers/tablets/lands/chemicals_controller_test.rb
@@ -37,4 +37,17 @@ class Tablets::Lands::ChemicalsControllerTest < ActionDispatch::IntegrationTest
     assert_select "label.btn.btn-outline-primary.btn-lg", text: chemical_types(:chemical_types0).name
     assert_select "input[type=hidden][name=regions][data-id='#{map_land.id}'][data-color='#ff4d4f']", 1
   end
+
+  test "タブレット版の農薬散布地図に他組織の土地を表示しない" do
+    other_land = lands(:land_other_org)
+    other_land.update!(region: "((35.474177,133.047340), (35.472866,133.047340), (35.472648,133.049056))")
+    other_work = works(:work_other_org)
+    other_work.update!(work_kind: work_kinds(:work_kind_taue))
+    WorkLand.create!(work: other_work, land: other_land, work_type_id: work_types(:work_type_koshi).id)
+
+    get tablets_lands_chemicals_path
+
+    assert_response :success
+    assert_select "input[type=hidden][name=regions][data-id='#{other_land.id}']", 0
+  end
 end

--- a/test/controllers/tablets/maps_controller_test.rb
+++ b/test/controllers/tablets/maps_controller_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class Tablets::MapsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    login_as(users(:users1))
+  end
+
+  test "タブレット版の地図に他組織の土地を表示しない" do
+    other_land = lands(:land_other_org)
+    other_land.update!(region: "((35.474177,133.047340), (35.472866,133.047340), (35.472648,133.049056))")
+
+    get tablets_maps_path
+
+    assert_response :success
+    assert_select "input#land_#{other_land.id}", count: 0
+  end
+end

--- a/test/services/lands/chemical_map_service_test.rb
+++ b/test/services/lands/chemical_map_service_test.rb
@@ -44,6 +44,7 @@ class Lands::ChemicalMapServiceTest < ActiveSupport::TestCase
     WorkChemical.create!(work: work, chemical: chemical3, quantity: 6.0)
 
     summaries = Lands::ChemicalMapService.call(
+      organization: organizations(:org),
       term: 2015,
       work_kind_id: work_kinds(:work_kind_taue).id,
       chemical_type_id: chemical_types(:chemical_types0).id
@@ -91,6 +92,7 @@ class Lands::ChemicalMapServiceTest < ActiveSupport::TestCase
     WorkChemical.create!(work: work, chemical: chemical, quantity: 2.0, chemical_group_no: 1)
 
     summaries = Lands::ChemicalMapService.call(
+      organization: organizations(:org),
       term: 2015,
       work_kind_id: work_kinds(:work_kind_taue).id,
       chemical_type_id: chemical_types(:chemical_types0).id
@@ -102,7 +104,12 @@ class Lands::ChemicalMapServiceTest < ActiveSupport::TestCase
   end
 
   test "基準量との差分率を7段階の色に分類する" do
-    service = Lands::ChemicalMapService.new(term: 2015, work_kind_id: work_kinds(:work_kind_taue).id, chemical_type_id: chemical_types(:chemical_types0).id)
+    service = Lands::ChemicalMapService.new(
+      organization: organizations(:org),
+      term: 2015,
+      work_kind_id: work_kinds(:work_kind_taue).id,
+      chemical_type_id: chemical_types(:chemical_types0).id
+    )
 
     assert_equal :over_50, service.send(:status_for, 0.5001.to_d)
     assert_equal :over_25, service.send(:status_for, 0.5.to_d)
@@ -122,6 +129,34 @@ class Lands::ChemicalMapServiceTest < ActiveSupport::TestCase
     assert_equal "#64d2ff", Lands::ChemicalMapService::COLORS.fetch(:under_10)
     assert_equal "#0a84ff", Lands::ChemicalMapService::COLORS.fetch(:under_25)
     assert_equal "#003a8c", Lands::ChemicalMapService::COLORS.fetch(:under_50)
+  end
+
+  test "他組織の作業を集計しない" do
+    other_land = lands(:land_other_org)
+    other_work = works(:work_other_org)
+    other_work.update!(work_kind: work_kinds(:work_kind_taue))
+    WorkLand.create!(work: other_work, land: other_land, work_type_id: work_types(:work_type_koshi).id)
+    LandCost.create!(land: other_land, work_type: work_types(:work_type_koshi), activated_on: Date.new(2015, 1, 1))
+
+    chemical = Chemical.create!(
+      organization: organizations(:org2),
+      chemical_type: chemical_types(:chemical_types0),
+      name: "別組織薬剤",
+      phonetic: "べつそしきやくざい",
+      display_order: 999
+    )
+    chemical_term = ChemicalTerm.create!(organization: organizations(:org2), chemical: chemical, term: 2015)
+    ChemicalWorkType.create!(chemical_term: chemical_term, work_type: work_types(:work_type_koshi), quantity: 1.0)
+    WorkChemical.create!(work: other_work, chemical: chemical, quantity: 5.0)
+
+    summaries = Lands::ChemicalMapService.call(
+      organization: organizations(:org),
+      term: 2015,
+      work_kind_id: work_kinds(:work_kind_taue).id,
+      chemical_type_id: chemical_types(:chemical_types0).id
+    )
+
+    assert_not summaries.key?(other_land.id)
   end
 
   private


### PR DESCRIPTION
# 複数組織対応を段階的に実施

Phase.7 対応

## 農薬散布地図の通常版・タブレット版を組織スコープ化

- app/controllers/lands/chemicals_controller.rb
- app/controllers/tablets/lands/chemicals_controller.rb
- 表示対象の Land.regionable を Land.for_organization(current_organization).regionable に変更。
- 対象土地 ID を拾う WorkLand.joins(:work) に works.organization_id 条件を追加。

## 農薬散布地図の集計 service を組織スコープ化

- app/services/lands/chemical_map_service.rb
- organization: 引数を追加。
- 集計対象の Work と ChemicalTerm を for_organization で制限。

## タブレット版の通常地図を組織スコープ化

- app/controllers/tablets/maps_controller.rb
- Land.regionable を Land.for_organization(current_organization).regionable に変更。

## 作付計画の初期化を組織スコープ化

- app/controllers/plans/lands_controller.rb
- app/models/plan_land.rb
- PlanLand.clear_all に組織を渡し、初期化対象の土地を Land.for_organization(organization) で制限。

## org2 fixture を使った混入防止テストを追加

- 通常版の農薬散布地図に他組織の土地を表示しない。
- タブレット版の農薬散布地図に他組織の土地を表示しない。
- タブレット版の通常地図に他組織の土地を表示しない。
- 作付計画の初期化で他組織の土地を登録しない。
- 農薬散布地図 service で他組織の作業を集計しない。
