### PR TITLE
#1048 Rouge 5.0.0 の HTMLLegacy 非推奨警告を解消する

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -6,7 +6,7 @@ module MarkdownHelper
   require "rouge"
 
   # 一度だけ初期化して使い回す（軽い最適化）
-  ROUGE_FORMATTER = Rouge::Formatters::HTMLLegacy.new
+  ROUGE_FORMATTER = Rouge::Formatters::HTML.new
 
   # GFM で欲しい拡張を共通定義
   GFM_EXTENSIONS = %i[TABLE_PREFER_STYLE_ATTRIBUTES FOOTNOTES STRIKETHROUGH TASKLISTS AUTOLINK].freeze
@@ -78,7 +78,7 @@ module MarkdownHelper
       lang = code["class"].to_s[/\blanguage-([A-Za-z0-9_+-]+)/, 1]
       lexer = pick_lexer(lang, code.text)
       highlighted = ROUGE_FORMATTER.format(lexer.lex(code.text))
-      code.parent.replace(%(<div class="highlight">#{highlighted}</div>))
+      code.parent.replace(%(<div class="highlight"><pre class="codehilite"><code>#{highlighted}</code></pre></div>))
     end
   end
 

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -4,6 +4,20 @@ require "test_helper"
 class MarkdownHelperTest < ActionView::TestCase
   include MarkdownHelper
 
+  test "コードブロックの HTML 構造と CSS クラスを維持する" do
+    html = markdown_to_html(<<~MD)
+      ```ruby
+      puts 'hello'
+      ```
+    MD
+
+    frag = Nokogiri::HTML::DocumentFragment.parse(html)
+    code = frag.at_css("div.highlight > pre.codehilite > code")
+
+    assert code, "Expected highlighted code block wrapper"
+    assert_equal "puts 'hello'\n", code.text
+  end
+
   # Markdown から生成されるすべてのタグが
   # sanitize の ALLOWED_TAGS に含まれているかチェックする
   test "Markdown から生成されるすべてのタグが sanitize の ALLOWED_TAGS に含まれているかチェックする" do


### PR DESCRIPTION
週末の bundle update で rouge が 4.7.0 から 5.0.0 に更新された。
Rails のテスト実行時に、以下の警告が表示される。

[DEPRECATED] Rouge::Formatters::HTMLLegacy is deprecated and will be removed soon. Please use one of the other formatters, or write your own.

原因は app/helpers/markdown_helper.rb の次の定数初期化。

ROUGE_FORMATTER = Rouge::Formatters::HTMLLegacy.new

Rouge 5.0.0 では HTMLLegacy.new の初期化時に非推奨警告が出る。