### PR TITLE
#1057 農地保守の検索条件

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -61,6 +61,7 @@ class HomesController < ApplicationController
         :display_order,
         :member_flag,
         :owner_flag,
+        :land_flag,
         :finance_order,
         :drying_order,
         :owned_rice_order,

--- a/app/controllers/lands/fees_controller.rb
+++ b/app/controllers/lands/fees_controller.rb
@@ -2,7 +2,7 @@ class Lands::FeesController < ApplicationController
   include PermitManager
 
   def index
-    @homes = Home.for_organization(current_organization).for_fee.landable
+    @homes = Home.for_organization(current_organization).for_fee.for_land_select
   end
 
   def edit

--- a/app/controllers/lands_controller.rb
+++ b/app/controllers/lands_controller.rb
@@ -67,7 +67,7 @@ class LandsController < ApplicationController
   end
 
   def set_homes
-    @homes = Home.for_organization(current_organization).landable.includes(:holder)
+    @homes = Home.for_organization(current_organization).for_land_select.includes(:holder)
   end
 
   def set_places

--- a/app/decorators/land_decorator.rb
+++ b/app/decorators/land_decorator.rb
@@ -17,10 +17,10 @@ class LandDecorator < Draper::Decorator
   def self.homes(organization = nil)
     hs = []
     hs << ["全て", ""]
-    homes = Home.landable.includes(:holder)
+    homes = Home.for_land_select.includes(:holder)
     homes = homes.for_organization(organization) if organization.present?
 
-    homes.find_each do |h|
+    homes.each do |h|
       hs << [h.owner_name, h.id]
     end
     hs

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -76,7 +76,7 @@ class Home < ApplicationRecord
       .where(company_flag: false)
       .usual_order
   }
-  scope :landable, lambda {
+  scope :for_land_select, lambda {
     kept
       .joins(:section).includes(:section)
       .order(Arel.sql("homes.company_flag, sections.display_order, homes.display_order, homes.id"))

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -11,6 +11,7 @@
 #  drying_order(出力順(乾燥調整用))    :integer
 #  fax(FAX番号)                        :string(15)
 #  finance_order(出力順(会計用))       :integer
+#  land_flag(土地フラグ)               :boolean          default(TRUE), not null
 #  location(位置)                      :point
 #  member_flag(組合員フラグ)           :boolean          default(TRUE), not null
 #  name(世帯名)                        :string(10)
@@ -78,6 +79,7 @@ class Home < ApplicationRecord
   }
   scope :for_land_select, lambda {
     kept
+      .where(land_flag: true)
       .joins(:section).includes(:section)
       .order(Arel.sql("homes.company_flag, sections.display_order, homes.display_order, homes.id"))
   }
@@ -103,6 +105,7 @@ class Home < ApplicationRecord
   validates :telephone, format: { with: REG_PHONE }, if: proc { |x| x.telephone.present? }
   validates :display_order, numericality: { only_integer: true }, if: proc { |x| x.display_order.present? }
   validate :section_belongs_to_same_organization
+  validate :land_flag_cannot_be_disabled_while_used
 
   def holder_name
     holder ? holder.name : ''
@@ -184,5 +187,12 @@ class Home < ApplicationRecord
     return if organization_id.blank? || section.blank? || section.organization_id == organization_id
 
     errors.add(:section_id, "は同じ組織の班を指定してください。")
+  end
+
+  def land_flag_cannot_be_disabled_while_used
+    return if land_flag || id.blank?
+    return unless owned_lands.exists? || managed_lands.exists? || sub_lands.exists?
+
+    errors.add(:land_flag, "は土地で使用されているため外せません。")
   end
 end

--- a/app/models/land.rb
+++ b/app/models/land.rb
@@ -118,6 +118,7 @@ class Land < ApplicationRecord
   validates :peasant_end_term, numericality: { only_integer: true }, allow_nil: true
   validate :homes_belong_to_same_organization
   validate :group_belongs_to_same_organization
+  validate :homes_have_land_flag
 
   accepts_nested_attributes_for :work_lands, allow_destroy: true
   accepts_nested_attributes_for :land_fees, allow_destroy: true
@@ -265,5 +266,10 @@ class Land < ApplicationRecord
     if group.present? && group.organization_id != organization_id
       errors.add(:group_id, "は同じ組織の土地を指定してください。")
     end
+  end
+
+  def homes_have_land_flag
+    errors.add(:owner_id, "は土地フラグが有効な世帯を指定してください。") if owner.present? && !owner.land_flag?
+    errors.add(:manager_id, "は土地フラグが有効な世帯を指定してください。") if manager.present? && !manager.land_flag?
   end
 end

--- a/app/models/land_home.rb
+++ b/app/models/land_home.rb
@@ -18,6 +18,7 @@ class LandHome < ApplicationRecord
   belongs_to :land
 
   validate :home_belongs_to_same_organization
+  validate :home_has_land_flag
 
   private
 
@@ -25,5 +26,11 @@ class LandHome < ApplicationRecord
     return if land.blank? || home.blank? || land.organization_id == home.organization_id
 
     errors.add(:home_id, "は土地と同じ組織の世帯を選択してください。")
+  end
+
+  def home_has_land_flag
+    return if home.blank? || home.land_flag?
+
+    errors.add(:home_id, "は土地フラグが有効な世帯を指定してください。")
   end
 end

--- a/app/views/homes/_form.html.erb
+++ b/app/views/homes/_form.html.erb
@@ -51,6 +51,17 @@
         <label for="home_owner_flag_false" class="form-check-label form-label">不可</label>
       </div>
     </div>
+    <div class="col-md-2 field mb-3">
+      <%= f.label :land_flag, class: "col-form-label-lg form-label" %>
+      <div class="form-check">
+        <%= f.radio_button :land_flag, true, {class: "form-check-input"} %>
+        <label for="home_land_flag_true" class="form-check-label form-label">可</label>
+      </div>
+      <div class="form-check">
+        <%= f.radio_button :land_flag, false, {class: "form-check-input"} %>
+        <label for="home_land_flag_false" class="form-check-label form-label">不可</label>
+      </div>
+    </div>
   </div>
   <div class="row">
     <div class="col-md-2 field mb-3">

--- a/app/views/lands/_homes.html.erb
+++ b/app/views/lands/_homes.html.erb
@@ -16,7 +16,7 @@
         <%= f.fields_for :land_homes do |fs| %>
         <tr style="visibility: <%= ((@owner_flag && fs.object.owner_flag) || (@manager_flag && fs.object.manager_flag)) ? 'visible' : 'collapse' %>">
           <td>
-          <%= fs.select(:home_id, options_from_collection_for_select(Home.landable.includes(:holder), :id, :owner_name, fs.object.home_id), {}, {class: "form-select"}) %>
+          <%= fs.select(:home_id, options_from_collection_for_select(Home.for_land_select.includes(:holder), :id, :owner_name, fs.object.home_id), {}, {class: "form-select"}) %>
           </td>
           <td>
           <%= fs.text_field :place, {maxlength: 15, required: true, class: "form-control"} %>

--- a/app/views/lands/_homes.html.erb
+++ b/app/views/lands/_homes.html.erb
@@ -16,7 +16,7 @@
         <%= f.fields_for :land_homes do |fs| %>
         <tr style="visibility: <%= ((@owner_flag && fs.object.owner_flag) || (@manager_flag && fs.object.manager_flag)) ? 'visible' : 'collapse' %>">
           <td>
-          <%= fs.select(:home_id, options_from_collection_for_select(Home.for_land_select.includes(:holder), :id, :owner_name, fs.object.home_id), {}, {class: "form-select"}) %>
+          <%= fs.select(:home_id, options_from_collection_for_select(Home.for_organization(@land.organization_id).for_land_select.includes(:holder), :id, :owner_name, fs.object.home_id), {}, {class: "form-select"}) %>
           </td>
           <td>
           <%= fs.text_field :place, {maxlength: 15, required: true, class: "form-control"} %>

--- a/config/locales/models/ja.attributes.yml
+++ b/config/locales/models/ja.attributes.yml
@@ -33,6 +33,7 @@ ja:
         display_order: "表示順"  #g
         member_flag: "組合員フラグ"
         owner_flag: "機械所有"
+        land_flag: "土地"
         finance_order: "出力順(会計用)"
         drying_order: "出力順(乾燥調整用)"
         owned_rice_order: "出力順(保有米用)"

--- a/db/migrate/20260612090000_add_land_flag_to_homes.rb
+++ b/db/migrate/20260612090000_add_land_flag_to_homes.rb
@@ -1,0 +1,5 @@
+class AddLandFlagToHomes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :homes, :land_flag, :boolean, null: false, default: true, comment: "土地フラグ"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgroonga"
@@ -365,6 +365,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_090000) do
     t.integer "drying_order", comment: "出力順(乾燥調整用)"
     t.string "fax", limit: 15, comment: "FAX番号"
     t.integer "finance_order", comment: "出力順(会計用)"
+    t.boolean "land_flag", default: true, null: false, comment: "土地フラグ"
     t.point "location", comment: "位置"
     t.boolean "member_flag", default: true, null: false, comment: "組合員フラグ"
     t.string "name", limit: 10, comment: "世帯名"

--- a/test/controllers/homes_controller_test.rb
+++ b/test/controllers/homes_controller_test.rb
@@ -4,7 +4,7 @@ class HomesControllerTest < ActionDispatch::IntegrationTest
   setup do
     login_as(users(:users1))
     @home = homes(:home1)
-    @update = { name: "試験", phonetic: "しけん", section_id: 1, member_flag: true, display_order: 99 }
+    @update = { name: "試験", phonetic: "しけん", section_id: 1, member_flag: true, land_flag: true, display_order: 99 }
   end
 
   test "世帯マスタ一覧" do
@@ -34,6 +34,7 @@ class HomesControllerTest < ActionDispatch::IntegrationTest
     assert_equal @update[:phonetic], home.phonetic
     assert_equal @update[:section_id], home.section_id
     assert_equal @update[:member_flag], home.member_flag
+    assert_equal @update[:land_flag], home.land_flag
     assert_equal @update[:display_order], home.display_order
   end
 
@@ -66,7 +67,16 @@ class HomesControllerTest < ActionDispatch::IntegrationTest
     assert_equal @update[:phonetic], @home.phonetic
     assert_equal @update[:section_id], @home.section_id
     assert_equal @update[:member_flag], @home.member_flag
+    assert_equal @update[:land_flag], @home.land_flag
     assert_equal @update[:display_order], @home.display_order
+  end
+
+  test "世帯マスタ変更(実行)(土地で使用中の世帯は土地フラグを外せない)" do
+    patch home_path(@home), params: { home: @update.merge(land_flag: false) }
+
+    assert_response :unprocessable_content
+    @home.reload
+    assert @home.land_flag
   end
 
   test "世帯マスタ変更(実行)(元のページへ戻る)" do

--- a/test/controllers/homes_controller_test.rb
+++ b/test/controllers/homes_controller_test.rb
@@ -71,6 +71,23 @@ class HomesControllerTest < ActionDispatch::IntegrationTest
     assert_equal @update[:display_order], @home.display_order
   end
 
+  test "世帯マスタ変更(実行)(土地で未使用の世帯は土地フラグを外せる)" do
+    home = Home.create!(
+      organization: organizations(:org),
+      section: sections(:sections0),
+      name: "土地外",
+      phonetic: "とちがい",
+      display_order: 999,
+      land_flag: true
+    )
+
+    patch home_path(home), params: { home: @update.merge(land_flag: "false") }
+
+    assert_redirected_to homes_path
+    home.reload
+    assert_not home.land_flag
+  end
+
   test "世帯マスタ変更(実行)(土地で使用中の世帯は土地フラグを外せない)" do
     patch home_path(@home), params: { home: @update.merge(land_flag: false) }
 

--- a/test/controllers/lands_controller_test.rb
+++ b/test/controllers/lands_controller_test.rb
@@ -17,6 +17,16 @@ class LandsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "土地マスタ一覧の世帯絞り込みは班順に表示" do
+    sections(:sections1).update!(display_order: 0)
+
+    get lands_path
+
+    expected_options = [["全て", ""]] + Home.for_organization(users(:users1).organization_id).for_land_select.includes(:holder).map { |home| [home.owner_name, home.id.to_s] }
+    actual_options = css_select("select#home option").map { |option| [option.text, option["value"]] }
+    assert_equal expected_options, actual_options
+  end
+
   test "土地マスタ一覧CSV出力" do
     get lands_path(format: :csv)
 

--- a/test/controllers/lands_controller_test.rb
+++ b/test/controllers/lands_controller_test.rb
@@ -27,6 +27,23 @@ class LandsControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_options, actual_options
   end
 
+  test "土地マスタ一覧の世帯絞り込みに土地フラグ無効の世帯は表示しない" do
+    home = Home.create!(organization: organizations(:org), section: sections(:sections0), name: "土地外", phonetic: "とちがい", display_order: 999, land_flag: false)
+
+    get lands_path
+
+    assert_select "select#home option[value=?]", home.id.to_s, false
+  end
+
+  test "土地マスタ変更画面の所有者管理者に土地フラグ無効の世帯は表示しない" do
+    home = Home.create!(organization: organizations(:org), section: sections(:sections0), name: "土地外", phonetic: "とちがい", display_order: 999, land_flag: false)
+
+    get edit_land_path(@land)
+
+    assert_select "select#land_owner_id option[value=?]", home.id.to_s, false
+    assert_select "select#land_manager_id option[value=?]", home.id.to_s, false
+  end
+
   test "土地マスタ一覧CSV出力" do
     get lands_path(format: :csv)
 

--- a/test/fixtures/homes.yml
+++ b/test/fixtures/homes.yml
@@ -11,6 +11,7 @@
 #  drying_order(出力順(乾燥調整用))    :integer
 #  fax(FAX番号)                        :string(15)
 #  finance_order(出力順(会計用))       :integer
+#  land_flag(土地フラグ)               :boolean          default(TRUE), not null
 #  location(位置)                      :point
 #  member_flag(組合員フラグ)           :boolean          default(TRUE), not null
 #  name(世帯名)                        :string(10)

--- a/test/models/home_test.rb
+++ b/test/models/home_test.rb
@@ -11,6 +11,7 @@
 #  drying_order(出力順(乾燥調整用))    :integer
 #  fax(FAX番号)                        :string(15)
 #  finance_order(出力順(会計用))       :integer
+#  land_flag(土地フラグ)               :boolean          default(TRUE), not null
 #  location(位置)                      :point
 #  member_flag(組合員フラグ)           :boolean          default(TRUE), not null
 #  name(世帯名)                        :string(10)
@@ -45,5 +46,26 @@ class HomeTest < ActiveSupport::TestCase
 
     assert_not home.valid?
     assert_includes home.errors[:section_id], "は同じ組織の班を指定してください。"
+  end
+
+  test "土地で使用中の世帯は土地フラグを外せない" do
+    home = homes(:home1)
+    home.land_flag = false
+
+    assert_not home.valid?
+    assert_includes home.errors[:land_flag], "は土地で使用されているため外せません。"
+  end
+
+  test "土地で未使用の世帯は土地フラグを外せる" do
+    home = Home.new(
+      organization: organizations(:org),
+      section: sections(:sections0),
+      name: "土地外",
+      phonetic: "とちがい",
+      display_order: 999,
+      land_flag: false
+    )
+
+    assert home.valid?
   end
 end

--- a/test/models/land_home_test.rb
+++ b/test/models/land_home_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class LandHomeTest < ActiveSupport::TestCase
+  test "土地フラグが無効な世帯を指定した場合は無効" do
+    home = Home.create!(organization: organizations(:org), section: sections(:sections0), name: "土地外", phonetic: "とちがい", display_order: 999, land_flag: false)
+    land_home = LandHome.new(land: lands(:lands0), home: home, place: "1", area: 1, owner_flag: true)
+
+    assert_not land_home.valid?
+    assert_includes land_home.errors[:home_id], "は土地フラグが有効な世帯を指定してください。"
+  end
+end

--- a/test/models/land_test.rb
+++ b/test/models/land_test.rb
@@ -123,6 +123,24 @@ class LandTest < ActiveSupport::TestCase
     assert_includes land.errors[:manager_id], "は同じ組織の世帯を指定してください。"
   end
 
+  test "土地フラグが無効な所有者を指定した場合は無効" do
+    home = Home.create!(organization: organizations(:org), section: sections(:sections0), name: "土地外", phonetic: "とちがい", display_order: 999, land_flag: false)
+    land = lands(:lands0)
+    land.owner = home
+
+    assert_not land.valid?
+    assert_includes land.errors[:owner_id], "は土地フラグが有効な世帯を指定してください。"
+  end
+
+  test "土地フラグが無効な管理者を指定した場合は無効" do
+    home = Home.create!(organization: organizations(:org), section: sections(:sections0), name: "土地外", phonetic: "とちがい", display_order: 999, land_flag: false)
+    land = lands(:lands0)
+    land.manager = home
+
+    assert_not land.valid?
+    assert_includes land.errors[:manager_id], "は土地フラグが有効な世帯を指定してください。"
+  end
+
   test "別組織のグループ土地を指定した場合は無効" do
     land = lands(:lands0)
     land.group = lands(:land_other_org)


### PR DESCRIPTION
- homesのorderにsectionが含まれていないので、含める。
- 世帯に「農地管理者フラグ」を追加し、それだけしか表示されないようにする。
- 世帯保守で「農地管理者フラグ」を保守できるようにする。ただし、既に農地の管理者となっている世帯は外せないようチェックを入れる。