### PR TITLE
#901 phase.9

### DIFF
--- a/app/controllers/gaps/health_controller.rb
+++ b/app/controllers/gaps/health_controller.rb
@@ -2,7 +2,7 @@ class Gaps::HealthController < GapsController
   def index
     return unless params[:work_type_id]
 
-    @healths, worker_ids = WorkResult.all_health(current_term, params[:work_type_id])
-    @workers = Worker.where(id: worker_ids).usual
+    @healths, worker_ids = WorkResult.all_health(current_term, params[:work_type_id], current_organization)
+    @workers = Worker.for_organization(current_organization).where(id: worker_ids).usual
   end
 end

--- a/app/controllers/personal_informations/schedules/workers_controller.rb
+++ b/app/controllers/personal_informations/schedules/workers_controller.rb
@@ -40,7 +40,7 @@ class PersonalInformations::Schedules::WorkersController < PersonalInformationsC
     @workers = if permitted_position?
                  workers_for_sections([@worker.home.section_id])
                else
-                 Worker.usual_order.where(home_id: @worker.home_id)
+                 Worker.for_organization(@worker.organization_id).usual_order.where(home_id: @worker.home_id)
                end
 
     @section_worker_management = permitted_position?
@@ -71,7 +71,10 @@ class PersonalInformations::Schedules::WorkersController < PersonalInformationsC
   end
 
   def workers_for_sections(section_ids)
-    Worker.usual_order.where(homes: { section_id: section_ids, company_flag: false })
+    Worker
+      .for_organization(@worker.organization_id)
+      .usual_order
+      .where(homes: { section_id: section_ids, company_flag: false })
   end
 
   def editable_worker_ids

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -14,7 +14,8 @@ class Users::PermissionsController < ApplicationController
   private
 
   def set_user
-    @user = User.find(params[:user_id])
+    @user = User.find_by(id: params[:user_id], organization_id: current_organization.id)
+    to_error_path if @user.blank?
   end
 
   def user_params

--- a/app/models/work_result.rb
+++ b/app/models/work_result.rb
@@ -175,10 +175,13 @@ class WorkResult < ApplicationRecord
     end
   end
 
-  def self.all_health(term, work_type_id)
+  def self.all_health(term, work_type_id, organization = nil)
     results = {}
     workers = []
-    Work.where(term: term, work_type_id: work_type_id).order(:worked_at, :id).each do |work|
+    works = Work.where(term: term, work_type_id: work_type_id)
+    works = works.for_organization(organization) if organization
+
+    works.order(:worked_at, :id).each do |work|
       result = results[work.worked_at] || {}
       work.work_results.each do |work_result|
         result[work_result.worker_id] = work_result.health_mark

--- a/test/controllers/gaps/health_controller_test.rb
+++ b/test/controllers/gaps/health_controller_test.rb
@@ -9,4 +9,17 @@ class Gaps::HealthControllerTest < ActionDispatch::IntegrationTest
     get gaps_health_index_path
     assert_response :success
   end
+
+  test "GAP体調確認表に他組織の作業者を表示しない" do
+    other_work_type_id = 999_999
+    health = Health.create!(code: "T", name: "テスト", well_flag: true)
+    works(:work_other_org).update!(work_type_id: other_work_type_id)
+    work_results(:work_result_other_org).update!(health: health)
+
+    get gaps_health_index_path, params: { work_type_id: other_work_type_id }
+
+    assert_response :success
+    assert_select "th", text: workers(:worker_other_org).family_name, count: 0
+    assert_select "th", text: workers(:worker_other_org).first_name, count: 0
+  end
 end

--- a/test/controllers/personal_informations/schedules/workers_controller_test.rb
+++ b/test/controllers/personal_informations/schedules/workers_controller_test.rb
@@ -55,6 +55,17 @@ class PersonalInformations::Schedules::WorkersControllerTest < ActionDispatch::I
     assert_select "input[name='worker_ids[]'][value='#{workers(:worker2).id}']", false
   end
 
+  test "個人情報(人員保守画面表示: 他組織作業者を表示しない)" do
+    get personal_information_schedules_workers_edit_path(
+      personal_information_token: @user.token,
+      schedule_id: @schedule.id
+    )
+
+    assert_response :success
+    assert_select "input[name=\"worker_ids[]\"][value=\"#{workers(:worker_other_org).id}\"]", false
+    assert_no_match workers(:worker_other_org).name, response.body
+  end
+
   test "個人情報(人員保守登録: 一般作業者は同一世帯のみ更新)" do
     user = users(:user_user)
 

--- a/test/controllers/users/permissions_controller_test.rb
+++ b/test/controllers/users/permissions_controller_test.rb
@@ -21,4 +21,19 @@ class Users::PermissionsControllerTest < ActionDispatch::IntegrationTest
     @user.reload
     assert_equal user[:permission_id], @user.permission_id.to_sym
   end
+
+  test "他組織ユーザの権限変更画面は表示しない" do
+    get new_user_permission_path(user_id: users(:user_admin_org2).id)
+
+    assert_response :service_unavailable
+  end
+
+  test "他組織ユーザの権限は変更しない" do
+    other_user = users(:user_admin_org2)
+
+    assert_no_changes -> { other_user.reload.permission_id } do
+      post user_permissions_path(user_id: other_user.id), params: { user: { permission_id: :manager } }
+    end
+    assert_response :service_unavailable
+  end
 end


### PR DESCRIPTION


ユーザ権限変更を組織スコープ化

    app/controllers/users/permissions_controller.rb
    User.find(params[:user_id]) を、ログインユーザの current_organization に属するユーザだけ取得する形に変更。
    他組織ユーザを直接指定した場合は 503 service_unavailable とし、権限変更も行わない。

GAP体調確認表を組織スコープ化

    app/controllers/gaps/health_controller.rb
    app/models/work_result.rb
    WorkResult.all_health に organization 引数を追加し、対象 Work を for_organization で制限。
    表示対象の Worker も Worker.for_organization(current_organization) で制限。
    既存呼び出しを壊さないよう、organization は任意引数にしている。

個人情報側の出役予定人員保守を明示的に組織スコープ化

    app/controllers/personal_informations/schedules/workers_controller.rb
    同一世帯の作業者取得と、対象班/助っ人候補の作業者取得を Worker.for_organization(@worker.organization_id) で制限。
    既に home/section 経由で間接的には絞れていたが、「入口で組織を明示する」方針に合わせた。

org2 fixture を使った混入防止テストを追加

    他組織ユーザの権限変更画面を表示しない。
    他組織ユーザの権限を POST で変更できない。
    GAP体調確認表に他組織作業者を表示しない。
    個人情報側の人員保守画面に他組織作業者を表示しない。

