### PR TITLE
#901 複数組織対応 phase.11 完了メモ: TaskTemplate の組織スコープ漏れ修正

### DIFF
--- a/app/controllers/tasks/templates_controller.rb
+++ b/app/controllers/tasks/templates_controller.rb
@@ -9,7 +9,7 @@ class Tasks::TemplatesController < ApplicationController
   decorates_assigned :templates, with: TaskTemplateDecorator
 
   def index
-    @templates = TaskTemplate.usual.page(params[:page])
+    @templates = TaskTemplate.for_organization(current_organization).usual.page(params[:page])
   end
 
   def new
@@ -44,7 +44,8 @@ class Tasks::TemplatesController < ApplicationController
   private
 
   def set_template
-    @template = TaskTemplate.find(params[:id])
+    @template = TaskTemplate.for_organization(current_organization).find_by(id: params[:id])
+    to_error_path unless @template
   end
 
   def template_params

--- a/app/models/task_template.rb
+++ b/app/models/task_template.rb
@@ -49,6 +49,9 @@ class TaskTemplate < ApplicationRecord
   before_save :set_offset
 
   scope :usual_order, -> { order(active: :desc, id: :desc) }
+  scope :for_organization, lambda { |organization|
+    where(organization_id: organization.is_a?(Organization) ? organization.id : organization)
+  }
   scope :usual, -> { with_discarded.usual_order }
   scope :for_auto_creation, -> { kept.where(active: true, kind: [:annual, :monthly]).usual_order }
   scope :for_hand_creation, -> { kept.where(active: true, kind: [:any_time]).usual_order }

--- a/test/controllers/tasks/templates_controller_test.rb
+++ b/test/controllers/tasks/templates_controller_test.rb
@@ -26,6 +26,13 @@ class Tasks::TemplatesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "定型タスク一覧に他組織テンプレートを表示しない" do
+    get task_templates_path
+
+    assert_response :success
+    assert_no_match task_templates(:template_other_org).title, @response.body
+  end
+
   test "定型タスク新規作成(実行)" do
     assert_difference('TaskTemplate.kept.count') do
       post task_templates_path, params: { task_template: @update }
@@ -76,5 +83,30 @@ class Tasks::TemplatesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to task_templates_path
     assert_response :redirect
+  end
+
+  test "他組織の定型タスクは直接指定しても変更画面を表示しない" do
+    get edit_task_template_path(task_templates(:template_other_org))
+
+    assert_response :service_unavailable
+  end
+
+  test "他組織の定型タスクは直接指定しても更新しない" do
+    other_template = task_templates(:template_other_org)
+
+    assert_no_changes -> { other_template.reload.title } do
+      patch task_template_path(other_template), params: { task_template: @update }
+    end
+    assert_response :service_unavailable
+  end
+
+  test "他組織の定型タスクは直接指定しても削除しない" do
+    other_template = task_templates(:template_other_org)
+
+    assert_no_difference("TaskTemplate.with_discarded.count") do
+      delete task_template_path(other_template)
+    end
+    assert_response :service_unavailable
+    assert_not_predicate other_template.reload, :discarded?
   end
 end

--- a/test/fixtures/task_templates.yml
+++ b/test/fixtures/task_templates.yml
@@ -53,4 +53,4 @@ template_other_org:
   months_before_due: 1
   office_role: finance
   offset: 0
-  active: true
+  active: false

--- a/test/fixtures/task_templates.yml
+++ b/test/fixtures/task_templates.yml
@@ -43,3 +43,14 @@ template1:
   office_role: finance
   offset: 0
   active: true
+
+template_other_org:
+  organization_id: 2
+  title: "他組織テンプレート"
+  kind: monthly
+  monthly_stage: w2
+  priority: low
+  months_before_due: 1
+  office_role: finance
+  offset: 0
+  active: true


### PR DESCRIPTION
## 概要

複数組織対応 Phase.11 として、`TaskTemplate` の組織スコープ漏れを修正しました。

## 変更内容

- `TaskTemplate.for_organization` scope を追加
- 定型タスク一覧を `current_organization` で絞り込み
- 定型タスクの `edit/update/destroy` 対象取得を `current_organization` で絞り込み
- 他組織テンプレートを直接指定した場合は `503 service_unavailable` とし、更新・削除しないよう修正
- org2 fixture を使った回帰テストを追加

## 確認内容

```text
bin/rails test test/controllers/tasks/templates_controller_test.rb

11 runs, 49 assertions, 0 failures, 0 errors, 0 skips