### PR TITLE
#901 Phase.12 作業詳細を組織スコープ化

### DIFF
--- a/app/controllers/harvest_whole_crops_controller.rb
+++ b/app/controllers/harvest_whole_crops_controller.rb
@@ -1,9 +1,10 @@
 class HarvestWholeCropsController < ApplicationController
   include PermitManager
+
   helper DryingsHelper
 
   def index
-    @whole_crops = WorkWholeCrop.for_harvest(current_term)
+    @whole_crops = WorkWholeCrop.for_organization(current_organization).for_harvest(current_term)
     respond_to do |format|
       format.html do
         @work_type_totals, @worked_at_totals = calc_totals(@whole_crops)

--- a/app/controllers/whole_crops_controller.rb
+++ b/app/controllers/whole_crops_controller.rb
@@ -3,7 +3,7 @@ class WholeCropsController < ApplicationController
 
   def index
     WorkWholeCrop.update_prices(current_system)
-    whole_crops = WorkWholeCrop.usual(current_term)
+    whole_crops = WorkWholeCrop.for_organization(current_organization).usual(current_term)
     respond_to do |format|
       format.html do
         @year_months = whole_crops.select("to_char(works.worked_at, 'YYYY-MM')")
@@ -13,10 +13,10 @@ class WholeCropsController < ApplicationController
       end
       format.csv do
         @whole_crops = if params[:ids].present?
-          WholeCropDecorator.decorate_collection(whole_crops.where(id: params[:ids]).usual_order)
-        else
-          WholeCropDecorator.decorate_collection(WorkWholeCrop.none)
-        end
+                         WholeCropDecorator.decorate_collection(whole_crops.where(id: params[:ids]).usual_order)
+                       else
+                         WholeCropDecorator.decorate_collection(WorkWholeCrop.none)
+                       end
         send_data render_to_string, filename: "whole_crops_#{Time.current.strftime('%Y%m%d%H%M%S')}.csv", type: :csv
       end
     end

--- a/app/controllers/work_results_controller.rb
+++ b/app/controllers/work_results_controller.rb
@@ -3,9 +3,10 @@ class WorkResultsController < ApplicationController
 
   def index
     @results = if params[:fixed_at]
-                 WorkResult.by_home_for_fix(current_term, Date.strptime(params[:fixed_at], '%Y-%m-%d'))
+                 WorkResult.for_organization(current_organization)
+                   .by_home_for_fix(current_term, Date.strptime(params[:fixed_at], '%Y-%m-%d'))
                else
-                 WorkResult.by_home(current_term)
+                 WorkResult.for_organization(current_organization).by_home(current_term)
                end
     @home_totals, @worker_totals = calc_totals(@results)
 

--- a/app/controllers/works/supporters_controller.rb
+++ b/app/controllers/works/supporters_controller.rb
@@ -2,7 +2,8 @@ class Works::SupportersController < ApplicationController
   include PermitManager
 
   def index
-    @results = WorkResultDecorator.decorate_collection(WorkResult.by_supporter_home(current_term))
+    results = WorkResult.for_organization(current_organization).by_supporter_home(current_term)
+    @results = WorkResultDecorator.decorate_collection(results)
     @home_totals, @month_totals = calc_totals(@results)
   end
 

--- a/app/models/work_broccoli.rb
+++ b/app/models/work_broccoli.rb
@@ -28,6 +28,9 @@ class WorkBroccoli < ApplicationRecord
 
   has_many :harvests, class_name: "BroccoliHarvest", dependent: :destroy
 
+  scope :for_organization, lambda { |organization|
+    joins(:work).where(works: { organization_id: organization.is_a?(Organization) ? organization.id : organization })
+  }
   scope :for_sales, lambda { |term|
     joins(:work)
       .where(["works.term = ? AND work_broccolis.sale > 0", term])

--- a/app/models/work_chemical.rb
+++ b/app/models/work_chemical.rb
@@ -33,6 +33,10 @@ class WorkChemical < ApplicationRecord
   validates :quantity, presence: true
   validates :quantity, numericality: { if: proc { |x| x.quantity.present? } }
 
+  scope :for_organization, lambda { |organization|
+    joins(:work).where(works: { organization_id: organization.is_a?(Organization) ? organization.id : organization })
+  }
+
   scope :by_term, lambda { |term, organization = nil|
     works = Work.arel_table
     chemicals = Chemical.arel_table

--- a/app/models/work_land.rb
+++ b/app/models/work_land.rb
@@ -24,6 +24,10 @@ class WorkLand < ApplicationRecord
   has_one    :work_kind, -> { with_deleted }, through: :work
   has_one    :wcs_land, class_name: "WholeCropLand", dependent: :destroy
 
+  scope :for_organization, lambda { |organization|
+    joins(:work).where(works: { organization_id: organization.is_a?(Organization) ? organization.id : organization })
+  }
+
   scope :for_personal, lambda { |home, term|
     joins(:work).includes(work: :work_kind)
       .joins(:land).includes(:land)

--- a/app/models/work_result.rb
+++ b/app/models/work_result.rb
@@ -40,6 +40,9 @@ class WorkResult < ApplicationRecord
   validates :hours, presence: true
   validates :hours, numericality: true, if: proc { |x| x.hours.present? }
 
+  scope :for_organization, lambda { |organization|
+    joins(:work).where(works: { organization_id: organization.is_a?(Organization) ? organization.id : organization })
+  }
   scope :by_worker_and_work, ->(worker, work) { where(worker_id: worker, work_id: work) }
 
   scope :by_home, lambda { |term|

--- a/app/models/work_verification.rb
+++ b/app/models/work_verification.rb
@@ -19,6 +19,10 @@ class WorkVerification < ApplicationRecord
 
   ENOUGH = 2
 
+  scope :for_organization, lambda { |organization|
+    joins(:work).where(works: { organization_id: organization.is_a?(Organization) ? organization.id : organization })
+  }
+
   def self.regist(work, worker)
     return if work.created_by == worker.id
 

--- a/app/models/work_whole_crop.rb
+++ b/app/models/work_whole_crop.rb
@@ -21,6 +21,9 @@ class WorkWholeCrop < ApplicationRecord
   has_many :wcs_lands, -> { order("whole_crop_lands.display_order") }, class_name: "WholeCropLand", dependent: :destroy
   has_many :wcs_rolls, through: :wcs_lands
 
+  scope :for_organization, lambda { |organization|
+    joins(:work).where(works: { organization_id: organization.is_a?(Organization) ? organization.id : organization })
+  }
   scope :usual_order, -> { joins(:work).order("works.worked_at, works.id") }
   scope :usual, ->(term) { joins(:work).where(works: { term: term }) }
   scope :for_harvest, lambda { |term|
@@ -56,7 +59,9 @@ class WorkWholeCrop < ApplicationRecord
 
   def self.update_prices(sys)
     # rubocop:disable Rails/SkipsModelValidations
-    joins(:work).where(works: { term: sys.term }).update_all(["unit_price = ?", sys.roll_price])
+    for_organization(sys.organization_id)
+      .where(works: { term: sys.term })
+      .update_all(["unit_price = ?", sys.roll_price])
     # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/app/models/work_work_type.rb
+++ b/app/models/work_work_type.rb
@@ -17,4 +17,8 @@ class WorkWorkType < ApplicationRecord
 
   belongs_to :work
   belongs_to :work_type
+
+  scope :for_organization, lambda { |organization|
+    joins(:work).where(works: { organization_id: organization.is_a?(Organization) ? organization.id : organization })
+  }
 end

--- a/test/controllers/harvest_whole_crops_controller_test.rb
+++ b/test/controllers/harvest_whole_crops_controller_test.rb
@@ -10,6 +10,16 @@ class HarvestWholeCropsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "収穫一覧の取得対象に他組織の作業を含めない" do
+    works(:work_other_org).update!(worked_at: Date.new(2015, 12, 31))
+    WorkWholeCrop.create!(work: works(:work_other_org))
+
+    get harvest_whole_crops_path
+
+    assert_response :success
+    assert_not_includes response.body, "2015-12-31"
+  end
+
   test "収穫一覧(WCS)(検証者以外)" do
     login_as(users(:user_checker))
     get harvest_whole_crops_path

--- a/test/controllers/whole_crops_controller_test.rb
+++ b/test/controllers/whole_crops_controller_test.rb
@@ -18,6 +18,22 @@ class WholeCropsControllerTest < ActionDispatch::IntegrationTest
     assert_equal work_whole_crop.unit_price, system.roll_price
   end
 
+  test "WCS一覧に他組織の作業を表示せず単価も更新しない" do
+    works(:work_other_org).update!(worked_at: Date.new(2015, 12, 31))
+    other_whole_crop = WorkWholeCrop.create!(
+      work: works(:work_other_org),
+      article_name: "別組織WCS",
+      unit_price: 99,
+      tax_rate: 8
+    )
+
+    get whole_crops_path
+
+    assert_response :success
+    assert_not_includes response.body, "2015-12-31"
+    assert_equal 99, other_whole_crop.reload.unit_price
+  end
+
   test "WCS一覧(管理者以外)" do
     login_as(users(:user_checker))
     get whole_crops_path

--- a/test/controllers/work_results_controller_test.rb
+++ b/test/controllers/work_results_controller_test.rb
@@ -6,10 +6,31 @@ class WorkResultsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "世帯別日当一覧" do
+    create_other_organization_result
+
     get work_results_path
     assert_response :success
+    assert_not_includes response.body, homes(:home_other_org).name
 
     get work_results_path, params: { fixed_at: "2015-02-28" }
     assert_response :success
+  end
+
+  test "確定日当一覧に他組織の作業結果を表示しない" do
+    works(:work_other_org).update!(fixed_at: Date.new(2015, 2, 28))
+    create_other_organization_result
+
+    get work_results_path, params: { fixed_at: "2015-02-28" }
+
+    assert_response :success
+    assert_not_includes response.body, homes(:home_other_org).name
+  end
+
+  private
+
+  def create_other_organization_result
+    WorkResult.find_or_create_by!(work: works(:work_other_org), worker: workers(:worker_other_org)) do |result|
+      result.hours = 4
+    end
   end
 end

--- a/test/fixtures/work_results.yml
+++ b/test/fixtures/work_results.yml
@@ -124,8 +124,8 @@ work_results6:
 
 work_result_other_org:
   id: 9000
-  work: work_other_org
-  worker: worker_other_org
+  work_id: 9000
+  worker_id: 9100
   hours: 4.0
   display_order: 1
   fixed_hours: 4.0

--- a/test/models/work_detail_organization_scope_test.rb
+++ b/test/models/work_detail_organization_scope_test.rb
@@ -15,7 +15,7 @@ class WorkDetailOrganizationScopeTest < ActiveSupport::TestCase
       create_work_broccoli,
       WorkWholeCrop.create!(work: other_work),
       WorkVerification.create!(work: other_work, worker: workers(:worker_other_org)),
-      WorkResult.create!(work: other_work, worker: workers(:worker1), hours: 1)
+      work_results(:work_result_other_org)
     ]
   end
 

--- a/test/models/work_detail_organization_scope_test.rb
+++ b/test/models/work_detail_organization_scope_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class WorkDetailOrganizationScopeTest < ActiveSupport::TestCase
+  test "作業詳細を親作業の組織で絞り込む" do
+    work_details.each { |record| assert_organization_scope(record) }
+    assert_work_work_type_scope
+  end
+
+  private
+
+  def work_details
+    [
+      WorkLand.create!(work: other_work, land: lands(:lands0), work_type: work_type),
+      WorkChemical.create!(work: other_work, chemical: chemical, quantity: 1, chemical_group_no: 2),
+      create_work_broccoli,
+      WorkWholeCrop.create!(work: other_work),
+      WorkVerification.create!(work: other_work, worker: workers(:worker_other_org)),
+      WorkResult.create!(work: other_work, worker: workers(:worker1), hours: 1)
+    ]
+  end
+
+  def create_work_broccoli
+    now = Time.current
+    # rubocop:disable Rails/SkipsModelValidations
+    WorkBroccoli.insert_all!([{ work_id: other_work.id, shipped_on: Date.current, created_at: now, updated_at: now }])
+    # rubocop:enable Rails/SkipsModelValidations
+    WorkBroccoli.find_by!(work: other_work)
+  end
+
+  def assert_organization_scope(record)
+    assert record.class.for_organization(organizations(:org2)).exists?(record.id), record.class.name
+    assert_not record.class.for_organization(organizations(:org)).exists?(record.id), record.class.name
+  end
+
+  def assert_work_work_type_scope
+    record = WorkWorkType.create!(work: other_work, work_type: work_type)
+    conditions = { work_id: record.work_id, work_type_id: record.work_type_id }
+
+    assert WorkWorkType.for_organization(organizations(:org2)).exists?(conditions)
+    assert_not WorkWorkType.for_organization(organizations(:org)).exists?(conditions)
+  end
+
+  def other_work
+    works(:work_other_org)
+  end
+
+  def work_type
+    work_types(:work_types1)
+  end
+
+  def chemical
+    work_chemicals(:work_chemical_other_org).chemical
+  end
+end

--- a/test/queries/work_total_age_query_test.rb
+++ b/test/queries/work_total_age_query_test.rb
@@ -2,19 +2,21 @@ require "test_helper"
 
 class WorkTotalAgeQueryTest < ActiveSupport::TestCase
   test "年度別年齢別作業集計クエリ" do
-    total_ages = WorkTotalAgeQuery.new.call
+    organization = organizations(:org)
+    total_ages = WorkTotalAgeQuery.new(organization: organization).call
+    works = Work.for_organization(organization).where(term: 2015)
 
-    total_hours = Work.joins(:work_results)
-      .where(term: 2015, "work_results.worker_id" => workers(:worker1).id).sum("work_results.hours")
+    total_hours = works.joins(:work_results)
+      .where("work_results.worker_id" => workers(:worker1).id).sum("work_results.hours")
     assert_equal total_hours, total_ages[[2015, 0]]
 
-    total_hours = Work.joins(:work_results)
-      .where(term: 2015, "work_results.worker_id" => workers(:worker2).id).sum("work_results.hours")
+    total_hours = works.joins(:work_results)
+      .where("work_results.worker_id" => workers(:worker2).id).sum("work_results.hours")
     assert_equal total_hours, total_ages[[2015, 2]]
 
-    total_hours = Work.joins(:work_results)
+    total_hours = works.joins(:work_results)
       .joins('INNER JOIN workers ON workers.id = work_results.worker_id AND workers.gender_id = 2')
-      .where(term: 2015).sum("work_results.hours")
+      .sum("work_results.hours")
     assert_equal total_hours, total_ages[[2015, 5]]
   end
 


### PR DESCRIPTION
### 今回やったこと

1. 作業詳細7モデルに組織スコープを追加
   - `WorkLand`
   - `WorkChemical`
   - `WorkBroccoli`
   - `WorkWholeCrop`
   - `WorkWorkType`
   - `WorkVerification`
   - `WorkResult`
   - 各モデルに `for_organization(organization)` を追加し、`Organization` オブジェクト / organization_id のどちらでも呼べる形にしました。
   - 各詳細テーブル自身への `organization_id` 追加は行わず、`joins(:work)` で親作業の組織を参照しています。

2. 日当・外注集計を組織スコープ化
   - `app/controllers/work_results_controller.rb`
   - `app/controllers/works/supporters_controller.rb`
   - 世帯別日当一覧、確定日当一覧、外注集計一覧の取得元を `WorkResult.for_organization(current_organization)` から始めるように変更しました。
   - 同一年度の他組織作業結果が一覧・集計へ混ざらないようにしました。

3. WCS一覧・収穫一覧を組織スコープ化
   - `app/controllers/whole_crops_controller.rb`
   - `app/controllers/harvest_whole_crops_controller.rb`
   - WCS一覧と収穫一覧を `WorkWholeCrop.for_organization(current_organization)` で制限しました。
   - CSV出力も同じスコープ済みrelationを使うため、他組織データを指定しても出力対象になりません。

4. WCS単価の一括更新を組織スコープ化
   - `app/models/work_whole_crop.rb`
   - `WorkWholeCrop.update_prices` が年度だけで全組織を更新していたため、`System#organization_id` でも絞り込むようにしました。
   - 組織1のWCS一覧表示によって、同年度の組織2の単価が更新されることを防止しています。

5. org2混入防止テストを追加
   - `test/models/work_detail_organization_scope_test.rb`
   - `test/controllers/work_results_controller_test.rb`
   - `test/controllers/whole_crops_controller_test.rb`
   - `test/controllers/harvest_whole_crops_controller_test.rb`
   - 追加した確認観点:
     - 7詳細モデルを親Workの組織で取得できる／他組織からは取得できない。
     - 世帯別日当一覧・確定日当一覧に他組織世帯を表示しない。
     - WCS一覧・収穫一覧に他組織作業を表示しない。
     - WCS一覧表示時に他組織の単価を更新しない。
