### PR TITLE
#1078 機械の表示順を統一

### DIFF
--- a/app/models/machine.rb
+++ b/app/models/machine.rb
@@ -40,7 +40,7 @@ class Machine < ApplicationRecord
   scope :with_deleted, -> { with_discarded }
   scope :only_deleted, -> { with_discarded.discarded }
   scope :ordered_for_display, lambda {
-    left_outer_joins(:machine_type)
+    joins(:machine_type)
       .order("machine_types.display_order, machine_types.id, machines.display_order, machines.id")
   }
 
@@ -67,7 +67,7 @@ class Machine < ApplicationRecord
   }
 
   scope :by_results, lambda { |results|
-    machine_ids = MachineResult.where(work_result_id: results.ids).select(:machine_id)
+    machine_ids = MachineResult.where(work_result_id: results.ids).select(:machine_id).distinct
 
     kept
       .where(id: machine_ids)

--- a/app/models/machine.rb
+++ b/app/models/machine.rb
@@ -39,6 +39,10 @@ class Machine < ApplicationRecord
 
   scope :with_deleted, -> { with_discarded }
   scope :only_deleted, -> { with_discarded.discarded }
+  scope :ordered_for_display, lambda {
+    joins(:machine_type)
+      .order("machine_types.display_order, machine_types.id, machines.display_order, machines.id")
+  }
 
   scope :by_work, lambda { |work|
     kept
@@ -51,7 +55,7 @@ class Machine < ApplicationRecord
         work.worked_at,
         work.machine_results.pluck(:machine_id)
       )
-      .order("machine_types.display_order, machines.display_order")
+      .ordered_for_display
   }
   scope :diesel, -> { kept.where(diesel_flag: true) }
 
@@ -63,17 +67,17 @@ class Machine < ApplicationRecord
   }
 
   scope :by_results, lambda { |results|
+    machine_ids = MachineResult.where(work_result_id: results.ids).select(:machine_id)
+
     kept
-      .joins(:machine_results)
-      .where(machine_results: { work_result_id: results.ids })
-      .order('machines.display_order')
-      .distinct
+      .where(id: machine_ids)
+      .ordered_for_display
   }
 
   scope :usual, lambda {
     kept
       .includes(:machine_type)
-      .order("machine_types.display_order, machines.display_order, machines.id")
+      .ordered_for_display
   }
 
   scope :trucks, lambda { |organization, section: nil|

--- a/app/models/machine.rb
+++ b/app/models/machine.rb
@@ -40,7 +40,7 @@ class Machine < ApplicationRecord
   scope :with_deleted, -> { with_discarded }
   scope :only_deleted, -> { with_discarded.discarded }
   scope :ordered_for_display, lambda {
-    joins(:machine_type)
+    left_outer_joins(:machine_type)
       .order("machine_types.display_order, machine_types.id, machines.display_order, machines.id")
   }
 

--- a/test/models/machine_test.rb
+++ b/test/models/machine_test.rb
@@ -18,6 +18,30 @@
 require "test_helper"
 
 class MachineTest < ActiveSupport::TestCase
+  test "ordered_for_display orders machines deterministically" do
+    owner = homes(:home1)
+    later_type = MachineType.create!(name: "後の機種", display_order: 2)
+    earlier_type = MachineType.create!(name: "先の機種", display_order: 1)
+    same_order_type = MachineType.create!(name: "同順位の機種", display_order: 1)
+
+    later_machine = create_machine(later_type, owner, display_order: 1)
+    same_type_later_machine = create_machine(earlier_type, owner, display_order: 2)
+    same_type_earlier_machine = create_machine(earlier_type, owner, display_order: 1)
+    same_type_same_order_machine = create_machine(earlier_type, owner, display_order: 1)
+    same_order_type_machine = create_machine(same_order_type, owner, display_order: 1)
+
+    machines = [
+      later_machine, same_type_later_machine, same_type_earlier_machine,
+      same_type_same_order_machine, same_order_type_machine
+    ]
+    expected = [
+      same_type_earlier_machine, same_type_same_order_machine, same_type_later_machine,
+      same_order_type_machine, later_machine
+    ]
+
+    assert_equal expected, Machine.where(id: machines).ordered_for_display
+  end
+
   test "trucks preloads owners" do
     truck_type = machine_types(:machine_types_removable)
     organization = organizations(:org)
@@ -36,5 +60,19 @@ class MachineTest < ActiveSupport::TestCase
 
     assert_includes trucks, truck
     assert_predicate trucks.find { |current_truck| current_truck.id == truck.id }.association(:owner), :loaded?
+  end
+
+  private
+
+  def create_machine(machine_type, owner, display_order:)
+    Machine.create!(
+      name: "",
+      display_order: display_order,
+      validity_start_at: Date.new(2015, 1, 1),
+      validity_end_at: Date.new(2099, 12, 31),
+      machine_type: machine_type,
+      owner: owner,
+      diesel_flag: false
+    )
   end
 end


### PR DESCRIPTION
- 日報照会
- 日報の機械入力
- 日報の機械コメント入力

の各画面で、orderがバラバラなので統一する。