### PR TITLE
年度別機械稼働時間一覧(statistics_machines)を追加

### DIFF
--- a/app/controllers/statistics/machines_controller.rb
+++ b/app/controllers/statistics/machines_controller.rb
@@ -1,0 +1,14 @@
+class Statistics::MachinesController < ApplicationController
+  include PermitManager
+
+  def index
+    @systems, machines, hours = StatisticsMachineQuery.new(current_organization).call
+    @machines = Statistics::MachineDecorator.decorate_collection(machines, context: { hours: hours })
+  end
+
+  private
+
+  def menu_name
+    :statistics_machines
+  end
+end

--- a/app/decorators/statistics/machine_decorator.rb
+++ b/app/decorators/statistics/machine_decorator.rb
@@ -1,0 +1,10 @@
+class Statistics::MachineDecorator < Draper::Decorator
+  delegate_all
+
+  def hours(term)
+    value = context[:hours][[term, object.id]]
+    return "" if value.blank? || value.zero?
+
+    h.number_to_currency(value, precision: 1, unit: "")
+  end
+end

--- a/app/queries/statistics_machine_query.rb
+++ b/app/queries/statistics_machine_query.rb
@@ -1,0 +1,24 @@
+class StatisticsMachineQuery
+  def initialize(organization)
+    @organization = organization
+  end
+
+  def call
+    systems = System.where(organization_id: @organization.id)
+      .where("start_date < ?", Time.zone.today)
+      .order(term: :desc).limit(10).to_a.reverse
+
+    hours = MachineResult
+      .joins(work_result: :work)
+      .where(works: { organization_id: @organization.id, term: systems.map(&:term) })
+      .group("works.term", :machine_id)
+      .sum(:hours)
+
+    machines = Machine.with_deleted
+      .includes(:machine_type)
+      .where(id: hours.keys.map(&:second).uniq)
+      .ordered_for_display
+
+    [systems, machines, hours]
+  end
+end

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -58,6 +58,7 @@
         <%= link_to '世帯別作業一覧', statistics_work_days_path, {class: "dropdown-item", data: {app_controller: "work_days"}} %>
         <%= link_to '作業者別作業一覧', statistics_workers_path, {class: "dropdown-item", data: {app_controller: "statistics_workers"}} %>
         <%= link_to '年度別作業効率一覧', statistics_areas_path, {class: "dropdown-item", data: {app_controller: "statistics_areas"}} %>
+        <%= link_to '年度別機械稼働時間一覧', statistics_machines_path, {class: "dropdown-item", data: {app_controller: "statistics_machines"}} %>
         <%= link_to 'カレンダー', calendars_path, {class: "dropdown-item", data: {app_controller: "calendars"}} %>
       <% end %>
     </div>

--- a/app/views/statistics/machines/index.html.erb
+++ b/app/views/statistics/machines/index.html.erb
@@ -1,0 +1,24 @@
+<h1>年度別機械稼働時間一覧</h1>
+<table class="table">
+  <thead>
+    <tr>
+      <th>機械種別</th>
+      <th>機械名</th>
+      <% @systems.each do |system| %>
+        <th class="numeric"><%= system.term_name %></th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% @machines.each do |machine| %>
+      <tr>
+        <th><%= machine.type_name %></th>
+        <th><%= machine.name %></th>
+        <% @systems.each do |system| %>
+          <td class="numeric"><%= machine.hours(system.term) %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= link_to '戻る', menu_index_path, class: "btn btn-outline-dark" %>

--- a/config/routes/all_routes.rb
+++ b/config/routes/all_routes.rb
@@ -184,6 +184,7 @@ namespace :statistics do
   resources :work_days, only: [:index]
   resources :workers, only: [:index]
   resources :areas, only: [:index]
+  resources :machines, only: [:index]
 end
 resources :statistics, only: [:index] do
   collection do

--- a/test/controllers/statistics/machines_controller_test.rb
+++ b/test/controllers/statistics/machines_controller_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class Statistics::MachinesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    login_as(users(:users1))
+  end
+
+  test "年度別機械稼働時間一覧" do
+    get statistics_machines_path
+    assert_response :success
+  end
+end

--- a/test/decorators/statistics/machine_decorator_test.rb
+++ b/test/decorators/statistics/machine_decorator_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class Statistics::MachineDecoratorTest < Draper::TestCase
+  test "#hours は稼働時間があれば小数点1位で返す" do
+    machine = machines(:machine_day_t)
+    decorated = Statistics::MachineDecorator.decorate(machine, context: { hours: { [2020, machine.id] => 4 } })
+
+    assert_equal "4.0", decorated.hours(2020)
+  end
+
+  test "#hours は集計が無ければ空文字を返す" do
+    machine = machines(:machine_day_t)
+    decorated = Statistics::MachineDecorator.decorate(machine, context: { hours: {} })
+
+    assert_equal "", decorated.hours(2020)
+  end
+
+  test "#hours は集計が0なら空文字を返す" do
+    machine = machines(:machine_day_t)
+    decorated = Statistics::MachineDecorator.decorate(machine, context: { hours: { [2020, machine.id] => 0 } })
+
+    assert_equal "", decorated.hours(2020)
+  end
+end

--- a/test/queries/statistics_machine_query_test.rb
+++ b/test/queries/statistics_machine_query_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class StatisticsMachineQueryTest < ActiveSupport::TestCase
+  test "年度別機械稼働時間一覧クエリ" do
+    organization = organizations(:org)
+    systems, machines, hours = StatisticsMachineQuery.new(organization).call
+
+    assert_equal [2014, 2015, 2016, 2017], systems.map(&:term)
+
+    machine_result = machine_results(:machine_result_for_price2)
+    work = machine_result.work_result.work
+
+    expected_hours = MachineResult
+      .joins(work_result: :work)
+      .where(machine_id: machine_result.machine_id, works: { term: work.term, organization_id: organization.id })
+      .sum(:hours)
+
+    assert_includes machines.map(&:id), machine_result.machine.id
+    assert_equal expected_hours, hours[[work.term, machine_result.machine_id]]
+  end
+end


### PR DESCRIPTION
## Summary
- `statistics_machines_path` に、term(年度)を横軸・機械種別/機械名を縦軸とした稼働時間のピボット表を追加
- 組織・直近10期(systems.start_date < 本日)で絞り込み、直近10期に実績のある機械のみ表示
- 集計が無い/0のセルは空欄、稼働時間は小数点1位固定で右詰め表示

## Test plan
- [x] `bin/rails test test/queries/statistics_machine_query_test.rb`
- [x] `bin/rails test test/decorators/statistics/machine_decorator_test.rb`
- [x] `bin/rails test test/controllers/statistics/machines_controller_test.rb`
- [x] rubocop（対象ファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)