### PR TITLE
#901 phase.13 タスク関連、予定関連

### DIFF
--- a/app/models/schedule_section.rb
+++ b/app/models/schedule_section.rb
@@ -10,4 +10,8 @@ class ScheduleSection < ApplicationRecord
 
   belongs_to :schedule
   belongs_to :section
+
+  scope :for_organization, lambda { |organization|
+    joins(:schedule).merge(Schedule.for_organization(organization))
+  }
 end

--- a/app/models/schedule_worker.rb
+++ b/app/models/schedule_worker.rb
@@ -26,8 +26,12 @@ class ScheduleWorker < ApplicationRecord
 
   before_create :set_uuid
 
+  scope :for_organization, lambda { |organization|
+    joins(:schedule).merge(Schedule.for_organization(organization))
+  }
+
   scope :for_personal, lambda { |worker, day|
-    joins(:schedule)
+    for_organization(worker.organization_id)
       .eager_load(:schedule)
       .joins("INNER JOIN work_kinds ON schedules.work_kind_id = work_kinds.id").preload(:work_kind)
       .where(["schedules.worked_at BETWEEN ? AND ?", Time.zone.today, Time.zone.today + day])
@@ -36,7 +40,7 @@ class ScheduleWorker < ApplicationRecord
   }
 
   scope :for_calendar, lambda { |worker|
-    joins(:schedule)
+    for_organization(worker.organization_id)
       .eager_load(:schedule)
       .joins("INNER JOIN work_kinds ON schedules.work_kind_id = work_kinds.id").preload(:work_kind)
       .where(["schedules.worked_at >= ? OR schedules.calendar_remove_flag = ?", Time.zone.today, false])

--- a/app/models/task_comment.rb
+++ b/app/models/task_comment.rb
@@ -32,6 +32,10 @@ class TaskComment < ApplicationRecord
   validates :body, presence: true, on: :create
   validate :poster_is_actor, if: -> { event.present? }
 
+  scope :for_organization, lambda { |organization|
+    joins(:task).merge(Task.for_organization(organization))
+  }
+
   private
 
   def strip_body

--- a/app/models/task_event.rb
+++ b/app/models/task_event.rb
@@ -62,6 +62,9 @@ class TaskEvent < ApplicationRecord
   after_commit :clear_if_comment_cleared, on: :update
   after_commit :clear_if_work_deleted, on: :update
 
+  scope :for_organization, lambda { |organization|
+    joins(:task).merge(Task.for_organization(organization))
+  }
   scope :usual_order, -> { includes(:actor, :comment).order(created_at: :asc, id: :asc) }
   scope :show_task, -> { where(source: [:form, :gantt, :calendar, :api]) }
 

--- a/app/models/task_read.rb
+++ b/app/models/task_read.rb
@@ -24,6 +24,10 @@ class TaskRead < ApplicationRecord
   belongs_to :task
   belongs_to :worker
 
+  scope :for_organization, lambda { |organization|
+    joins(:task).merge(Task.for_organization(organization))
+  }
+
   def self.touch_and_get_previous!(task:, worker_id:, at: Time.current)
     rec = find_or_initialize_by(task: task, worker_id: worker_id)
     prev = rec.last_read_at || Time.zone.at(0)

--- a/app/models/task_watcher.rb
+++ b/app/models/task_watcher.rb
@@ -22,4 +22,8 @@
 class TaskWatcher < ApplicationRecord
   belongs_to :task
   belongs_to :worker
+
+  scope :for_organization, lambda { |organization|
+    joins(:task).merge(Task.for_organization(organization))
+  }
 end

--- a/test/models/task_schedule_detail_organization_scope_test.rb
+++ b/test/models/task_schedule_detail_organization_scope_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class TaskScheduleDetailOrganizationScopeTest < ActiveSupport::TestCase
+  test "タスク関連を親タスクの組織で絞り込む" do
+    task_records.each { |record| assert_organization_scope(record) }
+  end
+
+  test "予定関連を親予定の組織で絞り込む" do
+    schedule_records.each { |record| assert_organization_scope(record) }
+  end
+
+  test "個人予定に他組織の予定を含めない" do
+    schedule = other_schedule
+    schedule.update_column(:worked_at, Time.zone.today) # rubocop:disable Rails/SkipsModelValidations
+    record = ScheduleWorker.create!(schedule: schedule, worker: workers(:worker1))
+
+    assert_not ScheduleWorker.for_personal(workers(:worker1), 1).exists?(record.id)
+  end
+
+  private
+
+  def task_records
+    task = other_task
+    [
+      TaskComment.create!(task: task, poster: other_worker, body: "別組織のコメント"),
+      task.events.first,
+      task.reads.first,
+      task.task_watchers.first
+    ]
+  end
+
+  def schedule_records
+    schedule = other_schedule
+    [
+      ScheduleSection.create!(schedule: schedule, section: sections(:section_other_org)),
+      ScheduleWorker.create!(schedule: schedule, worker: other_worker)
+    ]
+  end
+
+  def assert_organization_scope(record)
+    conditions = Array(record.class.primary_key).zip(Array(record.id)).to_h
+
+    assert record.class.for_organization(organizations(:org2)).where(conditions).exists?, record.class.name
+    assert_not record.class.for_organization(organizations(:org)).where(conditions).exists?, record.class.name
+  end
+
+  def other_task
+    @other_task ||= Task.create!(
+      organization: organizations(:org2),
+      title: "別組織のタスク",
+      creator: other_worker,
+      assignee: other_worker
+    )
+  end
+
+  def other_schedule
+    @other_schedule ||= schedules(:schedule1).dup.tap do |schedule|
+      schedule.organization = organizations(:org2)
+      schedule.created_by = other_worker.id
+      schedule.term = 2015
+      schedule.save!(validate: false)
+    end
+  end
+
+  def other_worker
+    workers(:worker_other_org)
+  end
+end

--- a/test/models/task_schedule_detail_organization_scope_test.rb
+++ b/test/models/task_schedule_detail_organization_scope_test.rb
@@ -58,7 +58,9 @@ class TaskScheduleDetailOrganizationScopeTest < ActiveSupport::TestCase
       schedule.organization = organizations(:org2)
       schedule.created_by = other_worker.id
       schedule.term = 2015
+      # rubocop:disable Rails/SkipsModelValidations
       schedule.save!(validate: false)
+      # rubocop:enable Rails/SkipsModelValidations
     end
   end
 


### PR DESCRIPTION


タスク関連4モデルに組織スコープを追加

    TaskComment
    TaskEvent
    TaskRead
    TaskWatcher
    各モデルに for_organization(organization) を追加しました。
    joins(:task).merge(Task.for_organization(organization)) により、親タスクの組織で絞り込みます。

予定関連2モデルに組織スコープを追加

    ScheduleSection
    ScheduleWorker
    各モデルに for_organization(organization) を追加しました。
    joins(:schedule).merge(Schedule.for_organization(organization)) により、親予定の組織で絞り込みます。

個人予定・個人カレンダーの取得を組織スコープ化

    ScheduleWorker.for_personal
    ScheduleWorker.for_calendar
    作業者の organization_id を使って親予定を制限し、同じ作業者IDが誤って他組織の予定に紐づいた場合でも画面・カレンダーへ混ざらないようにしました。

org2 混入防止テストを追加

    test/models/task_schedule_detail_organization_scope_test.rb
    追加した確認観点:
        タスク関連4モデルを親Taskの組織で取得できる／他組織からは取得できない。
        予定関連2モデルを親Scheduleの組織で取得できる／他組織からは取得できない。
        個人予定に他組織のScheduleWorkerが混ざらない。

