### PR TITLE
#10 年度対応 phase.1 

### DIFF
--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -34,7 +34,7 @@ class System < ApplicationRecord
   before_validation :set_default_term_name
 
   validates :term, presence: true
-  validates :term, numericality: { only_integer: true, greater_than: 2000, less_than: 2100 }
+  validates :term, numericality: { only_integer: true, greater_than: 0 }
   validates :term_name, presence: true, length: { maximum: 10 }
   validate :validate_period_dates
   validate :validate_period_continuity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,9 @@ services:
       - type: volume
         source: gemini_home
         target: /root/.gemini
+      - type: volume
+        source: ssh_home
+        target: /root/.ssh
       - type: tmpfs
         target: /farm2/tmp
       - type: tmpfs
@@ -125,3 +128,4 @@ volumes:
   vscode_server:
   claude_home:
   gemini_home:
+  ssh_home:

--- a/test/models/system_test.rb
+++ b/test/models/system_test.rb
@@ -108,4 +108,30 @@ class SystemTest < ActiveSupport::TestCase
 
     assert_predicate system, :valid?
   end
+
+  test "termは西暦年の範囲に縛られず、1年未満の期間を挟めること" do
+    # 年度末を12月末から3月末に変更する場合を想定し、
+    # 前期(s2017: 2017-01-01〜2017-12-31)の直後に3ヶ月だけの期を挿入する。
+    system = System.new(
+      organization_id: organizations(:org).id,
+      term: 2018,
+      term_name: "2018(3ヶ月)",
+      start_date: Date.new(2018, 1, 1),
+      end_date: Date.new(2018, 3, 31)
+    )
+
+    assert_predicate system, :valid?
+  end
+
+  test "termは2100以上の値でも有効であること" do
+    system = System.new(
+      organization_id: organizations(:org).id,
+      term: 2101,
+      term_name: "2101",
+      start_date: Date.new(2018, 1, 1),
+      end_date: Date.new(2018, 12, 31)
+    )
+
+    assert_predicate system, :valid?
+  end
 end


### PR DESCRIPTION
system.rb の term validation(2000〜2100の西暦年チェック)を撤廃し、正の整数程度に緩和