### PR TITLE
#901 複数団体対応

### DIFF
--- a/app/controllers/depreciations_controller.rb
+++ b/app/controllers/depreciations_controller.rb
@@ -2,19 +2,21 @@ class DepreciationsController < ApplicationController
   include PermitManager
 
   def index
-    @machines = Machine.includes(:owner).of_company.between_term(current_system).usual
+    @machines = Machine.for_organization(current_organization)
+      .includes(:owner).of_company.between_term(current_system).usual
     @work_types = WorkType.land
-    @depreciations = Depreciation.includes(:work_types).usual(current_term)
+    @depreciations = Depreciation.for_organization(current_organization).includes(:work_types).usual(current_term)
   end
 
   def create
     Depreciation.transaction do
       params[:depreciations].each do |dep_param|
         if dep_param[:id].present?
-          depreciation = Depreciation.find(dep_param[:id])
+          depreciation = Depreciation.for_organization(current_organization).find(dep_param[:id])
           depreciation.update(depreciation_params(dep_param))
         else
-          depreciation = Depreciation.create(depreciation_params(dep_param))
+          machine = Machine.for_organization(current_organization).find(dep_param[:machine_id])
+          depreciation = Depreciation.create(depreciation_params(dep_param).merge(machine: machine))
         end
         depreciation.regist_work_types(dep_param[:work_types]) if dep_param[:work_types]
       end

--- a/app/controllers/depreciations_controller.rb
+++ b/app/controllers/depreciations_controller.rb
@@ -11,11 +11,11 @@ class DepreciationsController < ApplicationController
   def create
     Depreciation.transaction do
       params[:depreciations].each do |dep_param|
+        machine = scoped_machine(dep_param)
         if dep_param[:id].present?
           depreciation = Depreciation.for_organization(current_organization).find(dep_param[:id])
-          depreciation.update(depreciation_params(dep_param))
+          depreciation.update(depreciation_params(dep_param).merge(machine: machine))
         else
-          machine = Machine.for_organization(current_organization).find(dep_param[:machine_id])
           depreciation = Depreciation.create(depreciation_params(dep_param).merge(machine: machine))
         end
         depreciation.regist_work_types(dep_param[:work_types]) if dep_param[:work_types]
@@ -27,6 +27,10 @@ class DepreciationsController < ApplicationController
   private
 
   def depreciation_params(params)
-    params.permit(:id, :cost, :machine_id, :term)
+    params.permit(:cost, :term)
+  end
+
+  def scoped_machine(params)
+    Machine.for_organization(current_organization).find(params[:machine_id])
   end
 end

--- a/app/controllers/machine_prices_controller.rb
+++ b/app/controllers/machine_prices_controller.rb
@@ -13,11 +13,12 @@ class MachinePricesController < ApplicationController
   end
 
   def show_machine
-    @machine = Machine.find(params[:machine_id])
+    @machine = find_machine(params[:machine_id])
     @machine_price = MachinePriceHeader.show_machine(@machine, Time.zone.today).first
   end
 
   def new
+    find_machine(params[:machine_id]) if params[:machine_id]
     @machine_price = if params[:machine_id]
                        MachinePriceHeader.new(machine_id: params[:machine_id], machine_type_id: 0, validated_at: Time.zone.today)
                      else
@@ -28,6 +29,7 @@ class MachinePricesController < ApplicationController
   def edit; end
 
   def create
+    find_machine(machine_price_header_params[:machine_id]) if machine_price_header_params[:machine_id].to_i.positive?
     @machine_price = MachinePriceHeader.new(machine_price_header_params)
     @machine_price.details_form = params[:details_form]
 
@@ -70,7 +72,7 @@ class MachinePricesController < ApplicationController
   private
 
   def set_machine_price
-    @machine_price = MachinePriceHeader.find(params[:id])
+    @machine_price = MachinePriceHeader.for_organization(current_organization).find(params[:id])
   end
 
   def set_adjusts
@@ -79,5 +81,9 @@ class MachinePricesController < ApplicationController
 
   def machine_price_header_params
     params.expect(machine_price_header: [:validated_at, :machine_id, :machine_type_id])
+  end
+
+  def find_machine(id)
+    Machine.for_organization(current_organization).find(id)
   end
 end

--- a/app/controllers/machines_controller.rb
+++ b/app/controllers/machines_controller.rb
@@ -6,7 +6,9 @@ class MachinesController < ApplicationController
   keeps_index_return_to path_method: :machines_path
 
   def index
-    @machines = MachineDecorator.decorate_collection(Machine.includes(:owner).usual.page(params[:page]))
+    @machines = MachineDecorator.decorate_collection(
+      Machine.for_organization(current_organization).includes(:owner).usual.page(params[:page])
+    )
   end
 
   def new
@@ -17,6 +19,7 @@ class MachinesController < ApplicationController
 
   def create
     @machine = Machine.new(machine_params)
+    @machine.owner = machine_owners.find(machine_params[:home_id])
     if @machine.save
       redirect_to machines_path
     else
@@ -25,6 +28,7 @@ class MachinesController < ApplicationController
   end
 
   def update
+    @machine.owner = machine_owners.find(machine_params[:home_id])
     if @machine.update(machine_params)
       redirect_to @return_to
     else
@@ -40,11 +44,11 @@ class MachinesController < ApplicationController
   private
 
   def set_machine
-    @machine = Machine.find(params[:id])
+    @machine = Machine.for_organization(current_organization).find(params[:id])
   end
 
   def set_masters
-    @homes = Home.machine_owners
+    @homes = machine_owners
     @machine_types = MachineType.usual
   end
 
@@ -52,5 +56,9 @@ class MachinesController < ApplicationController
     params.expect(machine:
           [:name, :display_order, :validity_start_at, :validity_end_at,
            :machine_type_id, :home_id, :number, :diesel_flag])
+  end
+
+  def machine_owners
+    Home.for_organization(current_organization).machine_owners
   end
 end

--- a/app/models/depreciation.rb
+++ b/app/models/depreciation.rb
@@ -21,6 +21,9 @@ class Depreciation < ApplicationRecord
   has_many :work_types, through: :depreciation_types
 
   scope :usual, ->(term) { joins(:machine, :machine_type).where(depreciations: { term: term }) }
+  scope :for_organization, lambda { |organization|
+    joins(machine: :owner).merge(Home.for_organization(organization))
+  }
 
   def regist_work_types(work_types)
     work_types.each do |work_type|

--- a/app/models/depreciation_type.rb
+++ b/app/models/depreciation_type.rb
@@ -16,4 +16,8 @@
 class DepreciationType < ApplicationRecord
   belongs_to :depreciation
   belongs_to :work_type
+
+  scope :for_organization, lambda { |organization|
+    joins(:depreciation).merge(Depreciation.for_organization(organization))
+  }
 end

--- a/app/models/machine.rb
+++ b/app/models/machine.rb
@@ -39,6 +39,9 @@ class Machine < ApplicationRecord
 
   scope :with_deleted, -> { with_discarded }
   scope :only_deleted, -> { with_discarded.discarded }
+  scope :for_organization, lambda { |organization|
+    joins(:owner).merge(Home.for_organization(organization))
+  }
   scope :ordered_for_display, lambda {
     joins(:machine_type)
       .order("machine_types.display_order, machine_types.id, machines.display_order, machines.id")

--- a/app/models/machine_price_detail.rb
+++ b/app/models/machine_price_detail.rb
@@ -19,11 +19,15 @@
 class MachinePriceDetail < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
 
-  belongs_to :header, class_name: 'MachinePriceHeader'
+  belongs_to :header, class_name: 'MachinePriceHeader', foreign_key: :machine_price_header_id
   belongs_to :work_kind
   belongs_to_active_hash :adjust
 
   enum :lease_id, { normal: 1, lease: 2 }
+
+  scope :for_organization, lambda { |organization|
+    joins(:header).merge(MachinePriceHeader.for_organization(organization))
+  }
 
   validates :price, presence: true
   validates :price, numericality: true, if: proc { |x| x.price.present? }

--- a/app/models/machine_price_header.rb
+++ b/app/models/machine_price_header.rb
@@ -27,6 +27,11 @@ class MachinePriceHeader < ApplicationRecord
   scope :show_type, ->(machine_type, base_date) { where("machine_type_id = ? AND validated_at <= ?", machine_type, base_date).order("validated_at DESC") }
   scope :show_machine, ->(machine, base_date) { where("machine_id = ? AND validated_at <= ?", machine, base_date).order("validated_at DESC") }
   scope :histories, ->(machine_price) { where("(machine_id = ? AND machine_id <> 0) OR (machine_type_id = ? AND machine_type_id <> 0)", machine_price.machine_id, machine_price.machine_type_id).order("validated_at ASC") }
+  scope :for_organization, lambda { |organization|
+    organization_id = organization.is_a?(Organization) ? organization.id : organization
+    left_joins(machine: :owner)
+      .where("machine_price_headers.machine_id = 0 OR homes.organization_id = ?", organization_id)
+  }
 
   def machine?
     !machine_id.zero?

--- a/app/models/machine_remark.rb
+++ b/app/models/machine_remark.rb
@@ -20,6 +20,8 @@ class MachineRemark < ApplicationRecord
   belongs_to  :machine, -> { with_deleted }
   belongs_to  :work
 
+  scope :for_organization, ->(organization) { joins(:work).merge(Work.for_organization(organization)) }
+
   def self.regist(work, remarks)
     work.machine_remarks.destroy_all
     remarks.each_value do |remark|

--- a/app/models/machine_result.rb
+++ b/app/models/machine_result.rb
@@ -33,6 +33,8 @@ class MachineResult < ApplicationRecord
   has_one :machine_type, -> { with_deleted }, through: :machine
   has_one :work_kind, -> { with_deleted }, through: :work
 
+  scope :for_organization, ->(organization) { joins(:work).merge(Work.for_organization(organization)) }
+
   scope :by_home, lambda { |term, organization = nil|
     machines = Machine.arel_table
     homes = Home.arel_table

--- a/test/controllers/depreciations_controller_test.rb
+++ b/test/controllers/depreciations_controller_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class DepreciationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    login_as(users(:users1))
+  end
+
+  test "他組織の機械へ減価償却を移動できない" do
+    depreciation = depreciations(:depreciation1)
+
+    assert_no_changes -> { depreciation.reload.attributes.slice("machine_id", "cost") } do
+      post depreciations_path, params: {
+        depreciations: [{
+          id: depreciation.id,
+          machine_id: machines(:machine_other_org).id,
+          cost: 100,
+          term: depreciation.term
+        }]
+      }
+    end
+
+    assert_response :not_found
+  end
+end

--- a/test/models/machine_organization_scope_test.rb
+++ b/test/models/machine_organization_scope_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class MachineOrganizationScopeTest < ActiveSupport::TestCase
+  setup do
+    @organization = organizations(:org)
+    @other_organization = organizations(:org2)
+    @machine = machines(:machines1)
+    @other_machine = machines(:machine_other_org)
+  end
+
+  test "機械を所有世帯の組織で絞り込む" do
+    assert_includes Machine.for_organization(@organization), @machine
+    assert_not_includes Machine.for_organization(@organization), @other_machine
+    assert_includes Machine.for_organization(@other_organization), @other_machine
+  end
+
+  test "機械稼働実績を親作業の組織で絞り込む" do
+    other_result = MachineResult.create!(machine: @other_machine, work_result: work_results(:work_result_other_org))
+    assert_not_includes MachineResult.for_organization(@organization), other_result
+    assert_includes MachineResult.for_organization(@other_organization), other_result
+  end
+
+  test "機械備考を親作業の組織で絞り込む" do
+    remark = MachineRemark.create!(machine: @other_machine, work: works(:work_other_org), other_remarks: "別組織")
+    assert_not_includes MachineRemark.for_organization(@organization), remark
+    assert_includes MachineRemark.for_organization(@other_organization), remark
+  end
+
+  test "機械単価と明細を所有世帯の組織で絞り込む" do
+    header = MachinePriceHeader.new(machine: @other_machine, machine_type_id: 0, validated_at: Date.new(2015, 1, 1))
+    header.details_form = {}
+    header.save!
+    detail = MachinePriceDetail.create!(
+      machine_price_header_id: header.id, work_kind_id: 0, lease_id: :normal, adjust_id: 1, price: 100
+    )
+    assert_not_includes MachinePriceHeader.for_organization(@organization), header
+    assert_includes MachinePriceHeader.for_organization(@other_organization), header
+    assert_not_includes MachinePriceDetail.for_organization(@organization), detail
+    assert_includes MachinePriceDetail.for_organization(@other_organization), detail
+  end
+
+  test "減価償却と分類を所有世帯の組織で絞り込む" do
+    depreciation = Depreciation.create!(machine: @other_machine, term: 2015, cost: 100)
+    depreciation_type = DepreciationType.create!(depreciation: depreciation, work_type: work_types(:work_types1))
+    assert_not_includes Depreciation.for_organization(@organization), depreciation
+    assert_includes Depreciation.for_organization(@other_organization), depreciation
+    assert_not_includes DepreciationType.for_organization(@organization), depreciation_type
+    assert_includes DepreciationType.for_organization(@other_organization), depreciation_type
+  end
+end


### PR DESCRIPTION
## 概要

複数組織対応を段階的に実装した `dev-901` を `develop` へ取り込みます。

refs #901

## 主な変更

- ログインユーザーの所属組織に基づくデータスコープを追加
- 各 controller / model / query の組織スコープ漏れを段階的に修正
- 作業、土地、世帯、タスク、予定、機械関連などで他組織データの混入を防止
- Phase.14 では機械、機械備考、稼働実績、機械単価、減価償却を既存の親関連経由で組織スコープ化
- org2 fixture を使った混入防止テストを追加

## Phase.14 の検証

```text
54 runs, 265 assertions, 0 failures, 0 errors, 0 skips
```

- `git diff --check`: 問題なし
- RuboCop: 今回追加箇所の新規違反なし
  - 既存箇所の複雑度・行長等と `.rubocop.yml` の移行警告は残存

## Phase.14 コミット

```text
10866b07 #901 phase.14 機械関連を組織スコープ化
```
