### PR TITLE
#10 phase.2 term_nameを年度表示に使用

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,5 +1,3 @@
-require 'wareki'
-
 module SessionsHelper
   def log_in(user, target: :PC)
     session[:user_id] = user.id
@@ -37,11 +35,11 @@ module SessionsHelper
   end
 
   def current_term_jp
-    current_system.start_date.strftime('%Jy年')
+    current_system.term_name
   end
 
   def next_term_jp
-    next_system.start_date.strftime('%Jy年')
+    next_system.term_name
   end
 
   def previous_term

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class SessionsHelperTest < ActionView::TestCase
+  include SessionsHelper
+
+  test "current_term_jp は現在期の年度名を返す" do
+    system = System.new(term_name: "第10期")
+    helper = Object.new.extend(SessionsHelper)
+
+    helper.stub(:current_system, system) do
+      assert_equal "第10期", helper.current_term_jp
+    end
+  end
+
+  test "next_term_jp は次期の年度名を返す" do
+    system = System.new(term_name: "第11期")
+    helper = Object.new.extend(SessionsHelper)
+
+    helper.stub(:next_system, system) do
+      assert_equal "第11期", helper.next_term_jp
+    end
+  end
+end

--- a/test/integration/change_term_test.rb
+++ b/test/integration/change_term_test.rb
@@ -24,7 +24,7 @@ class ChangeTermTest < ActionDispatch::IntegrationTest
     new_system = System.find_by(term: new_term, organization_id: @organization.id)
     get menu_index_path
     assert_response :success
-    assert_select 'h1', /#{new_system.start_date.strftime('%Jy年')}/
+    assert_select 'h1', /#{new_system.term_name}/
   end
 
   def teardown

--- a/test/integration/change_term_test.rb
+++ b/test/integration/change_term_test.rb
@@ -24,7 +24,7 @@ class ChangeTermTest < ActionDispatch::IntegrationTest
     new_system = System.find_by(term: new_term, organization_id: @organization.id)
     get menu_index_path
     assert_response :success
-    assert_select 'h1', /#{new_system.term_name}/
+    assert_select 'h1', /#{Regexp.escape(new_system.term_name)}/
   end
 
   def teardown


### PR DESCRIPTION
## 概要

Issue #10 Phase.2 として、年度表示を開始日の和暦変換ではなく `System#term_name` から取得するよう変更しました。

## 変更内容

- `current_term_jp` が `current_system.term_name` を返すよう変更
- `next_term_jp` が `next_system.term_name` を返すよう変更
- `sessions_helper.rb` の不要な `wareki` 読み込みを削除
- 任意の年度名（例: `第10期`）を検証するヘルパーテストを追加
- 対象年度変更の結合テストを `term_name` 表示に更新

## 影響

呼び出し側のビューは変更せず、System に設定された年度名をそのまま表示します。

## 確認

- `bin/rails test test/helpers/sessions_helper_test.rb test/integration/change_term_test.rb`
  - 3 runs / 9 assertions / 0 failures / 0 errors
- 変更したテストの RuboCop: 違反なし
- `git diff --check`: 問題なし

Refs #10