### PR TITLE
#901 Phase.15 圃場関連を組織スコープ化

### DIFF
--- a/app/controllers/harvest_rices_controller.rb
+++ b/app/controllers/harvest_rices_controller.rb
@@ -14,7 +14,11 @@ class HarvestRicesController < ApplicationController
     carried_on_totals = Hash.new { |h, k| h[k] = {} }
     areas = {}
     dryings.each do |drying|
-      areas[drying.carried_on] = LandCost.sum_area_for_harvest(drying.carried_on, current_organization.harvesting_work_kind_id) unless areas[drying.carried_on]
+      unless areas[drying.carried_on]
+        areas[drying.carried_on] = LandCost.sum_area_for_harvest(
+          drying.carried_on, current_organization.harvesting_work_kind_id, current_organization
+        )
+      end
       work_type_totals = set_totals1(work_type_totals, drying, drying.work_type_id)
       carried_on_totals = set_totals2(carried_on_totals, drying, drying.work_type_id, drying.carried_on)
     end

--- a/app/controllers/land_costs_controller.rb
+++ b/app/controllers/land_costs_controller.rb
@@ -30,11 +30,12 @@ class LandCostsController < ApplicationController
       params[:land_costs].each_value do |land_cost|
         next if land_cost[:work_type_id].blank? || land_cost[:land_id].blank? || land_cost[:activated_on].blank?
 
+        land = Land.for_organization(current_organization).find(land_cost[:land_id])
         if land_cost[:id].present?
-          @land_cost = LandCost.joins(:land).where(lands: { organization_id: current_organization.id }).find(land_cost[:id])
+          @land_cost = LandCost.for_organization(current_organization).find(land_cost[:id])
           session[:land_cost] = @land_cost.attributes unless @land_cost.update_work_type(land_cost_params(land_cost), current_system.start_date)
         else
-          @land_cost = LandCost.new(land_cost_params(land_cost))
+          @land_cost = land.land_costs.new(land_cost_params(land_cost).except(:land_id))
           session[:land_cost] = @land_cost.attributes unless @land_cost.save
         end
       end

--- a/app/controllers/lands/fees_controller.rb
+++ b/app/controllers/lands/fees_controller.rb
@@ -15,7 +15,7 @@ class Lands::FeesController < ApplicationController
 
   def update
     Home.for_organization(current_organization).find(params[:id])
-    LandFee.save_all_from_params(params[:id], fee_params)
+    LandFee.save_all_from_params(current_organization, params[:id], fee_params)
     redirect_to(lands_fees_path)
   end
 

--- a/app/controllers/lands/straws_controller.rb
+++ b/app/controllers/lands/straws_controller.rb
@@ -2,7 +2,7 @@ class Lands::StrawsController < ApplicationController
   include PermitManager
 
   def index
-    @straws = LandCost.for_straws(params[:term] || current_term, current_organization.straw_id)
+    @straws = LandCost.for_straws(params[:term] || current_term, current_organization.straw_id, current_organization)
     @work_types = WorkType.where(id: @straws.keys).usual
   end
 end

--- a/app/controllers/seedling_costs_controller.rb
+++ b/app/controllers/seedling_costs_controller.rb
@@ -6,7 +6,7 @@ class SeedlingCostsController < ApplicationController
     @work_types = WorkType.land
     @seedlings = Seedling.usual(current_term, @work_types)
     @seedling_quantities = SeedlingHome.total(@seedlings)
-    @lands = LandCost.total(Time.zone.today)
+    @lands = LandCost.total(Time.zone.today, current_organization)
   end
 
   def edit

--- a/app/controllers/work_chemicals_controller.rb
+++ b/app/controllers/work_chemicals_controller.rb
@@ -27,7 +27,9 @@ class WorkChemicalsController < ApplicationController
       next if work_chemical.work.work_lands.empty?
 
       land_ids = work_chemical.work.work_lands.map(&:land_id)
-      LandCost.sum_area_by_lands(work_chemical.work.worked_at, land_ids).each do |work_type_id, area|
+      LandCost.sum_area_by_lands(
+        work_chemical.work.worked_at, land_ids, work_chemical.work.organization_id
+      ).each do |work_type_id, area|
         chemical_work_type = ChemicalWorkType.by_work_chemical(work_chemical, work_type_id)
         next unless chemical_work_type
 

--- a/app/controllers/work_seedlings_controller.rb
+++ b/app/controllers/work_seedlings_controller.rb
@@ -21,7 +21,7 @@ class WorkSeedlingsController < ApplicationController
     work_seedlings = Hash.new { |h, k| h[k] = {} }
     work_areas = Hash.new { |h, k| h[k] = {} }
     works.each do |work|
-      LandCost.sum_area_by_lands(work.worked_at, work.lands.ids).each do |work_type_id, area|
+      LandCost.sum_area_by_lands(work.worked_at, work.lands.ids, work.organization_id).each do |work_type_id, area|
         work_seedlings[work_type_id][work.id] = work.sum_seedlings(work_type_id)
         work_areas[work_type_id][work.id] = area
       end

--- a/app/models/land_cost.rb
+++ b/app/models/land_cost.rb
@@ -56,7 +56,7 @@ class LandCost < ApplicationRecord
       .by_work_type(work_type_id, target)
       .where("lands.deleted_at IS NULL AND target_flag = true")
       .where("? BETWEEN lands.start_on AND lands.end_on", target)
-      .sum(:area)
+      .sum("lands.area")
   end
 
   def self.sum_area_for_harvest(worked_at, work_kind_id, organization)

--- a/app/models/land_cost.rb
+++ b/app/models/land_cost.rb
@@ -20,6 +20,8 @@ class LandCost < ApplicationRecord
 
   validates :activated_on, presence: true
 
+  scope :for_organization, ->(organization) { joins(:land).merge(Land.for_organization(organization)) }
+
   scope :newest, lambda { |target|
     latest_land_costs = arel_table.alias("lc2")
     latest_activated_on = latest_land_costs[:activated_on].maximum
@@ -41,23 +43,25 @@ class LandCost < ApplicationRecord
   scope :by_work_type, ->(work_type_id, target) { newest(target).where(work_type_id: work_type_id) }
   scope :by_land, ->(land_id) { where(land_id: land_id).order(activated_on: :asc).joins(:work_type) }
 
-  scope :total, ->(target) { joins(:land).newest(target).group(:work_type_id).sum("lands.area") }
+  scope :total, lambda { |target, organization|
+    for_organization(organization).newest(target).group(:work_type_id).sum("lands.area")
+  }
 
-  def self.sum_area_by_lands(target, land_ids)
-    LandCost.newest(target).where(land_id: land_ids).group(:work_type_id).joins(:land).sum(:area)
+  def self.sum_area_by_lands(target, land_ids, organization)
+    for_organization(organization).newest(target).where(land_id: land_ids).group(:work_type_id).sum("lands.area")
   end
 
-  def self.sum_area_by_work_type(target, work_type_id)
-    LandCost.by_work_type(work_type_id, target)
-      .joins(:land)
+  def self.sum_area_by_work_type(target, work_type_id, organization)
+    for_organization(organization)
+      .by_work_type(work_type_id, target)
       .where("lands.deleted_at IS NULL AND target_flag = true")
       .where("? BETWEEN lands.start_on AND lands.end_on", target)
       .sum(:area)
   end
 
-  def self.sum_area_for_harvest(worked_at, work_kind_id)
+  def self.sum_area_for_harvest(worked_at, work_kind_id, organization)
     results = {}
-    Work.where(worked_at: worked_at, work_kind_id: work_kind_id).find_each do |work|
+    Work.for_organization(organization).where(worked_at: worked_at, work_kind_id: work_kind_id).find_each do |work|
       work.lands.each do |land|
         land_cost = land.cost(worked_at)
         next if land_cost.nil?
@@ -70,13 +74,20 @@ class LandCost < ApplicationRecord
     results
   end
 
-  def self.for_straws(term, work_type_id)
-    LandCost.newest(Date.new(term.to_i, 4, 1)).joins(:land).where([<<SQL.squish, work_type_id, term]).group("land_costs.work_type_id").sum("lands.area")
-      EXISTS (SELECT * FROM work_lands#{' '}
-        INNER JOIN works ON works.id = work_lands.work_id AND works.work_type_id = ? AND works.term = ?
+  def self.for_straws(term, work_type_id, organization)
+    organization_id = organization.is_a?(Organization) ? organization.id : organization
+    exists_sql = <<~SQL.squish
+      EXISTS (SELECT * FROM work_lands
+        INNER JOIN works ON works.id = work_lands.work_id AND works.work_type_id = ? AND works.term = ? AND works.organization_id = ?
         WHERE lands.id = work_lands.land_id
       )
-SQL
+    SQL
+
+    for_organization(organization)
+      .newest(Date.new(term.to_i, 4, 1))
+      .where([exists_sql, work_type_id, term, organization_id])
+      .group("land_costs.work_type_id")
+      .sum("lands.area")
   end
 
   def self.all_sum_area_by_work_type(sys)
@@ -92,7 +103,7 @@ SQL
       result = []
       result << day
       work_types.each do |work_type|
-        result << sum_area_by_work_type(day, work_type.id)
+        result << sum_area_by_work_type(day, work_type.id, sys.organization_id)
       end
       results << result
     end

--- a/app/models/land_fee.rb
+++ b/app/models/land_fee.rb
@@ -27,10 +27,13 @@ class LandFee < ApplicationRecord
     transaction do
       params.each_value do |attributes|
         land = lands.find(attributes[:land_id])
-        fee = attributes[:id].present? ? fees.find(attributes[:id]) : new
+        fee = if attributes[:id].present?
+                fees.find_by!(id: attributes[:id], land_id: land.id)
+              else
+                land.land_fees.new
+              end
 
         fee.assign_attributes(attributes.except(:id, :land_id))
-        fee.land = land
         fee.save!
       end
     end

--- a/app/models/land_fee.rb
+++ b/app/models/land_fee.rb
@@ -18,15 +18,18 @@
 class LandFee < ApplicationRecord
   belongs_to :land
 
-  def self.save_all_from_params(_home_id, params)
-    params.each_value do |attributes|
-      fee = LandFee.find_by(id: attributes[:id])
+  scope :for_organization, ->(organization) { joins(:land).merge(Land.for_organization(organization)) }
 
-      if fee
-        fee.update(attributes)
-      else
-        LandFee.create(attributes)
-      end
+  def self.save_all_from_params(organization, home_id, params)
+    lands = Land.for_organization(organization).where(owner_id: home_id)
+
+    params.each_value do |attributes|
+      land = lands.find(attributes[:land_id])
+      fee = attributes[:id].present? ? for_organization(organization).find(attributes[:id]) : new
+
+      fee.assign_attributes(attributes.except(:id, :land_id))
+      fee.land = land
+      fee.save!
     end
   end
 end

--- a/app/models/land_fee.rb
+++ b/app/models/land_fee.rb
@@ -22,14 +22,17 @@ class LandFee < ApplicationRecord
 
   def self.save_all_from_params(organization, home_id, params)
     lands = Land.for_organization(organization).where(owner_id: home_id)
+    fees = for_organization(organization).where(land_id: lands.select(:id))
 
-    params.each_value do |attributes|
-      land = lands.find(attributes[:land_id])
-      fee = attributes[:id].present? ? for_organization(organization).find(attributes[:id]) : new
+    transaction do
+      params.each_value do |attributes|
+        land = lands.find(attributes[:land_id])
+        fee = attributes[:id].present? ? fees.find(attributes[:id]) : new
 
-      fee.assign_attributes(attributes.except(:id, :land_id))
-      fee.land = land
-      fee.save!
+        fee.assign_attributes(attributes.except(:id, :land_id))
+        fee.land = land
+        fee.save!
+      end
     end
   end
 end

--- a/app/models/land_home.rb
+++ b/app/models/land_home.rb
@@ -17,6 +17,8 @@ class LandHome < ApplicationRecord
   belongs_to :home, -> { with_deleted }
   belongs_to :land
 
+  scope :for_organization, ->(organization) { joins(:land).merge(Land.for_organization(organization)) }
+
   validate :home_belongs_to_same_organization
   validate :home_has_land_flag
 

--- a/app/models/sorimachi_journal.rb
+++ b/app/models/sorimachi_journal.rb
@@ -166,7 +166,7 @@ class SorimachiJournal < ApplicationRecord
     sum_area = 0
     max_work_type_id = 0
     max_area = 0
-    land_costs = LandCost.total(accounted_on || sys.end_date)
+    land_costs = LandCost.total(accounted_on || sys.end_date, sys.organization_id)
     land_costs.each do |land_cost|
       next unless copy_src.work_types.ids.include?(land_cost[0])
 

--- a/app/models/total_cost.rb
+++ b/app/models/total_cost.rb
@@ -104,7 +104,7 @@ class TotalCost < ApplicationRecord
 
   def base_cost(work_type_id)
     cost = cost(work_type_id)
-    sum_area = LandCost.sum_area_by_work_type(occurred_on, work_type_id)
+    sum_area = LandCost.sum_area_by_work_type(occurred_on, work_type_id, organization_id)
     return 0 if sum_area.zero?
 
     cost && !sum_area.zero? ? cost / sum_area * 10 : 0
@@ -156,7 +156,7 @@ class TotalCost < ApplicationRecord
     if work.work_type.cost_flag || work.work_lands.exists?
       make_work_details(work, total_cost)
     else
-      make_details_for_indirect(total_cost.id, work.worked_at)
+      make_details_for_indirect(total_cost, work.worked_at)
     end
   end
 
@@ -168,7 +168,7 @@ class TotalCost < ApplicationRecord
         area: 0
       )
     elsif (work.work_lands&.count || 0).positive?
-      LandCost.sum_area_by_lands(work.worked_at, work.lands.ids).each do |k, v|
+      LandCost.sum_area_by_lands(work.worked_at, work.lands.ids, work.organization_id).each do |k, v|
         TotalCostDetail.create(
           total_cost_id: total_cost.id,
           work_type_id: k,
@@ -179,20 +179,20 @@ class TotalCost < ApplicationRecord
       TotalCostDetail.create(
         total_cost_id: total_cost.id,
         work_type_id: work.work_type_id,
-        area: LandCost.sum_area_by_work_type(work.worked_at, work.work_type_id)
+        area: LandCost.sum_area_by_work_type(work.worked_at, work.work_type_id, work.organization_id)
       )
     end
   end
 
-  def self.make_details_for_indirect(total_cost_id, occurred_on)
+  def self.make_details_for_indirect(total_cost, occurred_on)
     WorkType.land.each do |work_type|
       next unless work_type.cost_flag
 
-      area = LandCost.sum_area_by_work_type(occurred_on, work_type.id)
+      area = LandCost.sum_area_by_work_type(occurred_on, work_type.id, total_cost.organization_id)
       next unless area.positive?
 
       TotalCostDetail.create(
-        total_cost_id: total_cost_id,
+        total_cost_id: total_cost.id,
         work_type_id: work_type.id,
         rate: 1,
         area: area

--- a/app/models/total_cost_detail.rb
+++ b/app/models/total_cost_detail.rb
@@ -21,10 +21,14 @@ class TotalCostDetail < ApplicationRecord
   belongs_to :total_cost
   belongs_to :work_type
 
+  scope :for_organization, lambda { |organization|
+    joins(:total_cost).merge(TotalCost.for_organization(organization))
+  }
+
   scope :lands, lambda { |term, days, organization = nil|
     base = joins(:total_cost)
       .where(total_costs: { term: term, total_cost_type_id: TotalCostType::LAND.id })
-    base = base.where(total_costs: { organization_id: organization.is_a?(Organization) ? organization.id : organization }) if organization
+    base = base.for_organization(organization) if organization
     base
       .group("total_cost_details.work_type_id")
       .sum("total_cost_details.area * total_cost_details.rate / #{days}")
@@ -33,7 +37,7 @@ class TotalCostDetail < ApplicationRecord
   scope :total_machines, lambda { |term, organization = nil|
     base = joins(:total_cost).includes(:total_cost)
       .where(total_costs: { term: term, total_cost_type_id: TotalCostType::MACHINE.id })
-    base = base.where(total_costs: { organization_id: organization.is_a?(Organization) ? organization.id : organization }) if organization
+    base = base.for_organization(organization) if organization
     base
       .group(["total_cost_details.work_type_id", "total_costs.machine_id"])
       .sum("total_cost_details.cost")
@@ -42,7 +46,7 @@ class TotalCostDetail < ApplicationRecord
   scope :areas, lambda { |term, days, organization = nil|
     base = joins(:total_cost)
       .where(total_costs: { term: term, total_cost_type_id: TotalCostType::AREA.id })
-    base = base.where(total_costs: { organization_id: organization.is_a?(Organization) ? organization.id : organization }) if organization
+    base = base.for_organization(organization) if organization
     base
       .group("total_cost_details.work_type_id")
       .sum("total_cost_details.area * total_cost_details.rate / #{days}")

--- a/app/queries/land_total_query.rb
+++ b/app/queries/land_total_query.rb
@@ -68,6 +68,7 @@ class LandTotalQuery
         work_lands[:work_id].eq(work[:id])
           .and(work[:work_kind_id].eq(id))
           .and(work[:term].eq(@sys.term))
+          .and(work[:organization_id].eq(@sys.organization_id))
       ]
     end
 
@@ -95,7 +96,11 @@ class LandTotalQuery
       query.join(work, Arel::Nodes::OuterJoin).on(join_condition)
     end
 
-    query.where(lands[:start_on].lteq(@sys.end_date).and(lands[:end_on].gteq(@sys.start_date)))
+    query.where(
+      lands[:organization_id].eq(@sys.organization_id)
+        .and(lands[:start_on].lteq(@sys.end_date))
+        .and(lands[:end_on].gteq(@sys.start_date))
+    )
     query.group(lands[:place], lands[:id])
     query.having(worked_at_columns.map { |worked_at| worked_at.not_eq(nil) }.reduce(&:or))
     query.order(lands[:parcel_number], max_owner_display_order, lands[:place], lands[:id])

--- a/app/views/harvest_rices/index.html.erb
+++ b/app/views/harvest_rices/index.html.erb
@@ -23,7 +23,7 @@
     <% if drying.work_type_id != old_work_type_id %>
       <% old_work_type_id = drying.work_type_id %>
       <% old_carried_on = nil %>
-      <% sum_area = LandCost.sum_area_by_work_type(current_system.start_date, old_work_type_id) %>
+      <% sum_area = LandCost.sum_area_by_work_type(current_system.start_date, old_work_type_id, current_organization) %>
       <tr class="tr-total1 table-row-primary-bg" data-code1="<%= old_work_type_id %>" data-action="click->grouped-rows#toggleTotal1 keydown->grouped-rows#onKeydown">
         <td><%= drying.work_type.name %></td>
         <td colspan="3"></td>

--- a/app/views/sorimachi/work_types/edit.html.erb
+++ b/app/views/sorimachi/work_types/edit.html.erb
@@ -10,7 +10,7 @@
     </div>
   </div>
   <hr>
-  <% land_costs = LandCost.total(@journal.accounted_on) %>
+  <% land_costs = LandCost.total(@journal.accounted_on, current_organization) %>
   <form id="sorimachi_form" action="<%= sorimachi_work_type_path(sorimachi_journal_id: @journal) %>" data-id="<%= @journal.id %>">
     <% total_amount = 0 %>
     <% @work_types.each do |work_type| %>

--- a/test/controllers/gaps/land_term_marks_controller_test.rb
+++ b/test/controllers/gaps/land_term_marks_controller_test.rb
@@ -48,6 +48,13 @@ class Gaps::LandTermMarksControllerTest < ActionDispatch::IntegrationTest
     get autocomplete_gaps_land_term_marks_path
 
     assert_response :success
-    assert_includes @response.parsed_body.map { |land| land["id"] }, lands(:lands1).id
+    assert_includes @response.parsed_body.pluck("id"), lands(:lands1).id
+  end
+
+  test "GAP圃場記号の候補に他組織の土地を含めない" do
+    get autocomplete_gaps_land_term_marks_path
+
+    assert_response :success
+    assert_not_includes @response.parsed_body.pluck("id"), lands(:land_other_org).id
   end
 end

--- a/test/controllers/land_costs_controller_test.rb
+++ b/test/controllers/land_costs_controller_test.rb
@@ -107,4 +107,20 @@ class LandCostsControllerTest < ActionDispatch::IntegrationTest
   teardown do
     travel_back
   end
+
+  test "他組織の土地には土地原価を作成しない" do
+    other_land = lands(:land_other_org)
+    attributes = {
+      0 => {
+        work_type_id: work_types(:work_types1).id,
+        land_id: other_land.id,
+        activated_on: Date.new(2015, 1, 1)
+      }
+    }
+
+    assert_no_difference("LandCost.count") do
+      post land_costs_path, params: { land_costs: attributes }
+    end
+    assert_response :not_found
+  end
 end

--- a/test/controllers/lands/fees_controller_test.rb
+++ b/test/controllers/lands/fees_controller_test.rb
@@ -82,6 +82,25 @@ class Lands::FeesControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "同じ世帯でも土地料金IDと土地IDが一致しない場合は更新しない" do
+    fee = land_fees(:land_fee1)
+    other_land = lands(:land_genka1)
+    update = {
+      other_land.id => {
+        manage_fee: 30_000,
+        peasant_fee: 40_000,
+        term: fee.term,
+        id: fee.id,
+        land_id: other_land.id
+      }
+    }
+
+    assert_no_changes -> { fee.reload.attributes.slice("land_id", "manage_fee", "peasant_fee") } do
+      patch lands_fee_path(id: @home_id), params: { land_fees: update }
+    end
+    assert_response :not_found
+  end
+
   test "土地料金の一括更新に失敗した場合は全件をロールバックする" do
     fee = land_fees(:land_fee1)
     original_manage_fee = fee.manage_fee

--- a/test/controllers/lands/fees_controller_test.rb
+++ b/test/controllers/lands/fees_controller_test.rb
@@ -44,4 +44,22 @@ class Lands::FeesControllerTest < ActionDispatch::IntegrationTest
     assert_equal update[land_genka2.id][:term], land_fee.term
     assert_equal update[land_genka2.id][:land_id], land_fee.land_id
   end
+
+  test "他組織の土地には土地料金を作成しない" do
+    other_land = lands(:land_other_org)
+    update = {
+      other_land.id => {
+        manage_fee: 30_000,
+        peasant_fee: 40_000,
+        term: 2015,
+        id: nil,
+        land_id: other_land.id
+      }
+    }
+
+    assert_no_difference("LandFee.count") do
+      patch lands_fee_path(id: @home_id), params: { land_fees: update }
+    end
+    assert_response :not_found
+  end
 end

--- a/test/controllers/lands/fees_controller_test.rb
+++ b/test/controllers/lands/fees_controller_test.rb
@@ -62,4 +62,49 @@ class Lands::FeesControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :not_found
   end
+
+  test "同じ組織でも別世帯の土地料金は更新しない" do
+    other_fee = LandFee.create!(land: lands(:lands0), term: 2015, manage_fee: 100, peasant_fee: 200)
+    land = lands(:land_genka2)
+    update = {
+      land.id => {
+        manage_fee: 30_000,
+        peasant_fee: 40_000,
+        term: 2015,
+        id: other_fee.id,
+        land_id: land.id
+      }
+    }
+
+    assert_no_changes -> { other_fee.reload.attributes.slice("land_id", "manage_fee", "peasant_fee") } do
+      patch lands_fee_path(id: @home_id), params: { land_fees: update }
+    end
+    assert_response :not_found
+  end
+
+  test "土地料金の一括更新に失敗した場合は全件をロールバックする" do
+    fee = land_fees(:land_fee1)
+    original_manage_fee = fee.manage_fee
+    update = {
+      fee.land_id => {
+        manage_fee: original_manage_fee + 1,
+        peasant_fee: fee.peasant_fee,
+        term: fee.term,
+        id: fee.id,
+        land_id: fee.land_id
+      },
+      lands(:land_other_org).id => {
+        manage_fee: 30_000,
+        peasant_fee: 40_000,
+        term: 2015,
+        id: nil,
+        land_id: lands(:land_other_org).id
+      }
+    }
+
+    assert_no_changes -> { fee.reload.manage_fee } do
+      patch lands_fee_path(id: @home_id), params: { land_fees: update }
+    end
+    assert_response :not_found
+  end
 end

--- a/test/models/land_detail_organization_scope_test.rb
+++ b/test/models/land_detail_organization_scope_test.rb
@@ -17,6 +17,8 @@ class LandDetailOrganizationScopeTest < ActiveSupport::TestCase
     assert_not_includes LandCost.for_organization(@organization), land_cost
     assert_includes LandCost.for_organization(@other_organization), land_cost
     assert_equal @other_land.area, LandCost.total(Date.new(2015, 1, 1), @other_organization)[land_cost.work_type_id]
+    assert_equal @other_land.area,
+                 LandCost.sum_area_by_work_type(Date.new(2015, 1, 1), land_cost.work_type_id, @other_organization)
   end
 
   test "土地料金を親土地の組織で絞り込む" do

--- a/test/models/land_detail_organization_scope_test.rb
+++ b/test/models/land_detail_organization_scope_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class LandDetailOrganizationScopeTest < ActiveSupport::TestCase
+  setup do
+    @organization = organizations(:org)
+    @other_organization = organizations(:org2)
+    @other_land = lands(:land_other_org)
+  end
+
+  test "土地原価を親土地の組織で絞り込む" do
+    land_cost = LandCost.create!(
+      land: @other_land,
+      work_type: work_types(:work_types1),
+      activated_on: Date.new(2015, 1, 1)
+    )
+
+    assert_not_includes LandCost.for_organization(@organization), land_cost
+    assert_includes LandCost.for_organization(@other_organization), land_cost
+    assert_equal @other_land.area, LandCost.total(Date.new(2015, 1, 1), @other_organization)[land_cost.work_type_id]
+  end
+
+  test "土地料金を親土地の組織で絞り込む" do
+    land_fee = LandFee.create!(land: @other_land, term: 2015, manage_fee: 100, peasant_fee: 200)
+
+    assert_not_includes LandFee.for_organization(@organization), land_fee
+    assert_includes LandFee.for_organization(@other_organization), land_fee
+  end
+
+  test "土地管理を親土地の組織で絞り込む" do
+    land_home = LandHome.create!(
+      land: @other_land,
+      home: homes(:home_other_org),
+      place: @other_land.place,
+      area: @other_land.area,
+      owner_flag: true
+    )
+
+    assert_not_includes LandHome.for_organization(@organization), land_home
+    assert_includes LandHome.for_organization(@other_organization), land_home
+  end
+
+  test "土地年度別記号を親土地の組織で絞り込む" do
+    land_term_mark = LandTermMark.create!(land: @other_land, term: 2015, mark: "Z")
+
+    assert_not_includes LandTermMark.for_organization(@organization), land_term_mark
+    assert_includes LandTermMark.for_organization(@other_organization), land_term_mark
+  end
+
+  test "集計原価明細を親集計原価の組織で絞り込む" do
+    total_cost = TotalCost.create!(
+      organization: @other_organization,
+      term: 2015,
+      occurred_on: Date.new(2015, 1, 1),
+      total_cost_type_id: TotalCostType::LAND.id,
+      amount: 100
+    )
+    detail = TotalCostDetail.create!(
+      total_cost: total_cost,
+      work_type: work_types(:work_types1),
+      area: 10,
+      cost: 100
+    )
+
+    assert_not_includes TotalCostDetail.for_organization(@organization), detail
+    assert_includes TotalCostDetail.for_organization(@other_organization), detail
+  end
+end

--- a/test/queries/land_total_query_test.rb
+++ b/test/queries/land_total_query_test.rb
@@ -30,4 +30,18 @@ class LandTotalQueryTest < ActiveSupport::TestCase
   test "有効な作業種別IDがない場合は空配列を返す" do
     assert_equal [], LandTotalQuery.new(["x", "0", "-1"], systems(:s2015)).call
   end
+
+  test "作業種別土地別作業日数一覧に他組織の土地を含めない" do
+    other_work = works(:work_other_org)
+    other_work.update!(
+      work_kind: work_kinds(:work_kind_shirokaki),
+      worked_at: Date.new(2015, 4, 1),
+      term: 2015
+    )
+    WorkLand.create!(work: other_work, land: lands(:land_other_org))
+
+    results = LandTotalQuery.new([work_kinds(:work_kind_shirokaki).id], systems(:s2015)).call
+
+    assert_not_includes results.map(&:place), lands(:land_other_org).place
+  end
 end


### PR DESCRIPTION
## Phase.15 完了メモ: 圃場関連の組織スコープ対応

Phase.15 の計画どおり、DB migration なしで、圃場関連と集計原価明細を既存の親関連経由で組織スコープ化しました。

refs #901

### 今回やったこと

1. 圃場関連モデルと集計原価明細に組織スコープを整備
   - `LandCost` / `LandFee` / `LandHome`: 親の `lands.organization_id`
   - `LandTermMark`: 既存の親土地経由スコープを回帰テストで確認
   - `TotalCostDetail`: 親の `total_costs.organization_id`
   - `TotalCostDetail.lands` / `total_machines` / `areas` も共通の `for_organization` を利用するようにしました。

2. 土地原価の集計処理を組織スコープ化
   - 作業分類別面積、土地別面積、収穫面積、稲わら対象面積、土地原価合計に組織引数を追加しました。
   - 原価計算、育苗費、農薬使用量、収穫一覧、稲わら一覧、ソリマチ関連の呼び出し元から所属組織を明示しました。
   - 同じ年度・作業分類の他組織データが面積や原価へ混ざらないようにしています。

3. 土地原価・土地料金の更新経路を組織スコープ化
   - 土地原価の作成・更新対象を `current_organization` の土地に限定しました。
   - 土地料金の一括更新では、所属組織かつ対象世帯が所有する土地だけを更新します。
   - ID や `land_id` を直接指定しても、他組織の土地関連データを作成・更新できません。

4. 圃場集計クエリを組織スコープ化
   - `LandTotalQuery` の土地と作業を `System#organization_id` で制限しました。
   - 他組織の土地・作業が作業種別土地別一覧へ混ざらないようにしています。

5. org2 混入防止テストを追加
   - 圃場関連4モデルと集計原価明細の `for_organization`
   - 他組織の土地への土地原価・土地料金の登録拒否
   - GAP圃場記号候補と圃場集計からの他組織データ除外
   - 関連する集計処理の回帰テスト

### 検証結果

全テスト:

```text
1073 runs, 4516 assertions, 0 failures, 0 errors, 0 skips
```

`git diff --check` は問題ありません。

変更ファイルに RuboCop を実行しました。今回追加したスコープと新規テストの主要6ファイルは違反なしです。全変更ファイル対象では既存箇所の複雑度・行長等47件と `.rubocop.yml` の移行警告が残るため終了コードは失敗ですが、今回追加した行に新規違反はありません。

### コミット

```text
5885a8f3 #901 phase.15 圃場関連を組織スコープ化
```

`dev-901` へ push 済みです。