### PR TITLE
#1106 薬剤登録画面: 希釈無選択時にmagnification/dilution_amountが残る不具合を修正

### DIFF
--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -17,7 +17,7 @@ module WorksHelper
         amount += work_chemical.dilution_amount || 0
       when Dilution::MAG
         unit = "倍"
-        amount += work_chemical.magnification
+        amount += work_chemical.magnification || 0
       end
     end
     amount.zero? || counter.zero? ? "" : (amount / counter).round(0).to_fs(:delimited, delimiter: ',') + unit

--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -14,7 +14,7 @@ module WorksHelper
       case dilution
       when Dilution::L
         unit = "ℓ"
-        amount += work_chemical.dilution_amount
+        amount += work_chemical.dilution_amount || 0
       when Dilution::MAG
         unit = "倍"
         amount += work_chemical.magnification

--- a/app/helpers/works_helper.rb
+++ b/app/helpers/works_helper.rb
@@ -7,18 +7,23 @@ module WorksHelper
 
   def chemical_dilution(work_chemicals, chemical_id)
     dilution = work_chemicals.where(chemical_id: chemical_id).order(:chemical_group_no).first.dilution
-    counter = work_chemicals.where(chemical_id: chemical_id).count
     amount = 0
+    counter = 0
     unit = ""
     work_chemicals.where(chemical_id: chemical_id).find_each do |work_chemical|
-      case dilution
-      when Dilution::L
-        unit = "ℓ"
-        amount += work_chemical.dilution_amount || 0
-      when Dilution::MAG
-        unit = "倍"
-        amount += work_chemical.magnification || 0
-      end
+      value =
+        case dilution
+        when Dilution::L
+          unit = "ℓ"
+          work_chemical.dilution_amount
+        when Dilution::MAG
+          unit = "倍"
+          work_chemical.magnification
+        end
+      next if value.nil?
+
+      amount += value
+      counter += 1
     end
     amount.zero? || counter.zero? ? "" : (amount / counter).round(0).to_fs(:delimited, delimiter: ',') + unit
   end

--- a/app/models/work_chemical.rb
+++ b/app/models/work_chemical.rb
@@ -89,6 +89,8 @@ class WorkChemical < ApplicationRecord
   end
 
   def dilution_amount
+    return nil if dilution_none?
+
     dilution? && chemical.unit_scale.positive? ? (quantity * magnification / chemical.unit_scale).round(1) : quantity
   end
 

--- a/app/services/work/chemicals_registrar.rb
+++ b/app/services/work/chemicals_registrar.rb
@@ -31,6 +31,8 @@ class Work::ChemicalsRegistrar
   private
 
   def quantity_params(quantity, add_params)
-    quantity.permit(:quantity, :dilution_id, :magnification, :remarks).merge(add_params)
+    permitted = quantity.permit(:quantity, :dilution_id, :magnification, :remarks)
+    permitted[:magnification] = nil if permitted[:dilution_id].to_i == Dilution::NONE.id
+    permitted.merge(add_params)
   end
 end

--- a/app/views/works/chemicals/new.html.erb
+++ b/app/views/works/chemicals/new.html.erb
@@ -85,8 +85,8 @@
                 <% Dilution.all.each do |dilution| %>
                   <%= radio_button_tag "chemicals[#{chemical.id}][#{index + 1}][dilution_id]", dilution.id,
                     effective_dilution_id == dilution.id,
-                    {id: "chamicals_#{chemical.id}_#{index + 1}_#{dilution.id}", class: "form-check-input", disabled: !chemical.aqueous_flag, data: {id: chemical.id, group: index + 1}} %>
-                  <%= label_tag "chamicals_#{chemical.id}_#{index + 1}_#{dilution.id}", dilution.name, class: "form-check-label" %>
+                    {id: "chemicals_#{chemical.id}_#{index + 1}_#{dilution.id}", class: "form-check-input", disabled: !chemical.aqueous_flag, data: {id: chemical.id, group: index + 1}} %>
+                  <%= label_tag "chemicals_#{chemical.id}_#{index + 1}_#{dilution.id}", dilution.name, class: "form-check-label" %>
                 <% end %>
               </div>
             </td>

--- a/app/views/works/chemicals/new.html.erb
+++ b/app/views/works/chemicals/new.html.erb
@@ -71,7 +71,7 @@
           <td><%= chemical_name(chemical) %>(<%= chemical.base_base_quantity %><%= chemical.base_unit_name %>)</td>
           <% group_count.times do |index| %>
             <% work_chemical = @work.work_chemicals.find_by(chemical_id: chemical.id, chemical_group_no: index + 1) %>
-            <% effective_dilution_id = (work_chemical&.dilution_id || Dilution::NONE.id).to_i %>
+            <% effective_dilution_id = chemical.aqueous_flag ? (work_chemical&.dilution_id || Dilution::NONE.id).to_i : Dilution::NONE.id %>
 
             <td class="col-data" data-index="<%= index %>" style="display:none;">
               <%= number_field_tag "chemicals[#{chemical.id}][#{index + 1}][quantity]", work_chemical&.quantity,
@@ -91,13 +91,15 @@
               </div>
             </td>
             <td class="col-data" data-index="<%= index %>" style="display:none;">
-              <%= number_field_tag "chemicals[#{chemical.id}][#{index + 1}][magnification]", work_chemical&.magnification,
+              <%= number_field_tag "chemicals[#{chemical.id}][#{index + 1}][magnification]",
+                (effective_dilution_id == Dilution::NONE.id ? nil : work_chemical&.magnification),
                 {disabled: effective_dilution_id == Dilution::NONE.id, readonly: effective_dilution_id != Dilution::MAG.id,
                 min: 0, max: 9999.9, step: 0.1, class: "form-control form-control-sm narrow",
                 data: {id: chemical.id, group: index + 1, unit: chemical.unit_scale}} %>
             </td>
             <td class="col-data" data-index="<%= index %>" style="display:none;">
-              <%= number_field_tag "chemicals[#{chemical.id}][#{index + 1}][dilution_amount]", work_chemical&.dilution_amount,
+              <%= number_field_tag "chemicals[#{chemical.id}][#{index + 1}][dilution_amount]",
+                (effective_dilution_id == Dilution::NONE.id ? nil : work_chemical&.dilution_amount),
                 {disabled: effective_dilution_id == Dilution::NONE.id, readonly: effective_dilution_id != Dilution::L.id,
                 min: 0, max: 9999.9, step: 0.1, class: "form-control form-control-sm narrow",
                 data: {id: chemical.id, group: index + 1, unit: chemical.unit_scale}} %>

--- a/app/views/works/chemicals/new.html.erb
+++ b/app/views/works/chemicals/new.html.erb
@@ -71,6 +71,7 @@
           <td><%= chemical_name(chemical) %>(<%= chemical.base_base_quantity %><%= chemical.base_unit_name %>)</td>
           <% group_count.times do |index| %>
             <% work_chemical = @work.work_chemicals.find_by(chemical_id: chemical.id, chemical_group_no: index + 1) %>
+            <% effective_dilution_id = (work_chemical&.dilution_id || Dilution::NONE.id).to_i %>
 
             <td class="col-data" data-index="<%= index %>" style="display:none;">
               <%= number_field_tag "chemicals[#{chemical.id}][#{index + 1}][quantity]", work_chemical&.quantity,
@@ -82,8 +83,8 @@
               <%= hidden_field_tag "chemicals[#{chemical.id}][#{index + 1}][dilution_id]", Dilution::NONE.id %>
               <div class="form-check-inline">
                 <% Dilution.all.each do |dilution| %>
-                  <%= radio_button_tag "chemicals[#{chemical.id}][#{index + 1}][dilution_id]", dilution.id, 
-                    work_chemical&.dilution_id == dilution.id,
+                  <%= radio_button_tag "chemicals[#{chemical.id}][#{index + 1}][dilution_id]", dilution.id,
+                    effective_dilution_id == dilution.id,
                     {id: "chamicals_#{chemical.id}_#{index + 1}_#{dilution.id}", class: "form-check-input", disabled: !chemical.aqueous_flag, data: {id: chemical.id, group: index + 1}} %>
                   <%= label_tag "chamicals_#{chemical.id}_#{index + 1}_#{dilution.id}", dilution.name, class: "form-check-label" %>
                 <% end %>
@@ -91,12 +92,14 @@
             </td>
             <td class="col-data" data-index="<%= index %>" style="display:none;">
               <%= number_field_tag "chemicals[#{chemical.id}][#{index + 1}][magnification]", work_chemical&.magnification,
-                {readonly: !work_chemical&.dilution_mag?, min: 0, max: 9999.9, step: 0.1, class: "form-control form-control-sm narrow",
+                {disabled: effective_dilution_id == Dilution::NONE.id, readonly: effective_dilution_id != Dilution::MAG.id,
+                min: 0, max: 9999.9, step: 0.1, class: "form-control form-control-sm narrow",
                 data: {id: chemical.id, group: index + 1, unit: chemical.unit_scale}} %>
             </td>
             <td class="col-data" data-index="<%= index %>" style="display:none;">
               <%= number_field_tag "chemicals[#{chemical.id}][#{index + 1}][dilution_amount]", work_chemical&.dilution_amount,
-                {readonly: !work_chemical&.dilution_l?, min: 0, max: 9999.9, step: 0.1, class: "form-control form-control-sm narrow",
+                {disabled: effective_dilution_id == Dilution::NONE.id, readonly: effective_dilution_id != Dilution::L.id,
+                min: 0, max: 9999.9, step: 0.1, class: "form-control form-control-sm narrow",
                 data: {id: chemical.id, group: index + 1, unit: chemical.unit_scale}} %>
             </td>
             <td class="col-data numeric" data-index="<%= index %>" style="display:none;" id="chemicals_<%= chemical.id %>_<%= index + 1 %>_quantity10">

--- a/test/controllers/works/chemicals_controller_test.rb
+++ b/test/controllers/works/chemicals_controller_test.rb
@@ -41,7 +41,7 @@ class Works::ChemicalsControllerTest < ActionDispatch::IntegrationTest
     get new_work_use_chemical_path(work_id: work)
 
     assert_response :success
-    assert_select "#chamicals_#{chemical.id}_1_#{Dilution::NONE.id}[checked]"
+    assert_select "#chemicals_#{chemical.id}_1_#{Dilution::NONE.id}[checked]"
     assert_select "input[name='chemicals[#{chemical.id}][1][magnification]'][disabled]"
     assert_select "input[name='chemicals[#{chemical.id}][1][dilution_amount]'][disabled]"
   end

--- a/test/controllers/works/chemicals_controller_test.rb
+++ b/test/controllers/works/chemicals_controller_test.rb
@@ -31,6 +31,21 @@ class Works::ChemicalsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to works_path
   end
 
+  test "作業変更(薬品)(表示)(希釈無のとき希釈情報は無選択かつdisabled)" do
+    work = works(:works1)
+    chemical = chemicals(:chemicals2)
+    work_chemical = work.work_chemicals.find_by(chemical_id: chemical.id, chemical_group_no: 1)
+    assert_not chemical.aqueous_flag
+    assert_equal Dilution::NONE.id, work_chemical.dilution_id
+
+    get new_work_use_chemical_path(work_id: work)
+
+    assert_response :success
+    assert_select "#chamicals_#{chemical.id}_1_#{Dilution::NONE.id}[checked]"
+    assert_select "input[name='chemicals[#{chemical.id}][1][magnification]'][disabled]"
+    assert_select "input[name='chemicals[#{chemical.id}][1][dilution_amount]'][disabled]"
+  end
+
   test "作業変更(薬品)(変更)" do
     chemical = chemicals(:chemicals3)
     chemicals = { chemical.id => { 1 => {
@@ -49,6 +64,32 @@ class Works::ChemicalsControllerTest < ActionDispatch::IntegrationTest
     assert_equal chemical.id, created_work_chemical.chemical_id
     assert_equal chemicals[4][1][:dilution_id], created_work_chemical.dilution_id
     assert_equal chemicals[4][1][:magnification], created_work_chemical.magnification
+  end
+
+  test "作業変更(薬品)(変更)(希釈なしに変更すると希釈倍率がクリアされる)" do
+    chemical = chemicals(:chemicals3)
+
+    post work_use_chemicals_path(work_id: @work), params: {
+      chemicals: { chemical.id => { 1 => {
+        dilution_id: 1, magnification: 10, dilution_amount: 10, quantity: 10
+      } } },
+      work: { chemical_group_flag: false }
+    }
+    work_chemical = WorkChemical.find_by(work_id: @work.id, chemical_id: chemical.id, chemical_group_no: 1)
+    assert_equal 10, work_chemical.magnification.to_i
+
+    # ブラウザ上は dilution_id を無に切り替えると magnification 欄が disabled になり送信されないため、
+    # そのケースを再現するためにパラメータから magnification を含めない
+    post work_use_chemicals_path(work_id: @work), params: {
+      chemicals: { chemical.id => { 1 => {
+        dilution_id: 0, quantity: 10
+      } } },
+      work: { chemical_group_flag: false }
+    }
+    work_chemical.reload
+    assert_equal 0, work_chemical.dilution_id
+    assert_nil work_chemical.magnification
+    assert_nil work_chemical.dilution_amount
   end
 
   test "作業変更(薬品)(変更)(薬剤グループ)" do


### PR DESCRIPTION
## 概要
`/works/:id/chemicals/new` で `dilution_id` を「無」に切り替えて保存すると、`magnification`/`dilution_amount` がDB上に残ってしまう不具合の修正です(issue #1106)。

## 原因
JS側で `dilution_id` を「無」に切り替えると `magnification` 入力欄を `disabled` にしていました。disabledな入力欄はフォーム送信時にブラウザから送信されないため、サーバー側の `Work::ChemicalsRegistrar#quantity_params` では `magnification` キー自体がパラメータに存在せず、DBの値が更新されないまま古い値が残っていました(見た目上はクリアされたように見えるだけ)。

## 対応
- `Work::ChemicalsRegistrar#quantity_params` で、`dilution_id` が「無」のときはサーバー側で明示的に `magnification` を `nil` にするよう修正
- `WorkChemical#dilution_amount` も「無」のときは `nil` を返すよう修正
- ビュー側で「無」を選んだ薬剤(希釈不可薬剤含む)が常に明示的に選択された状態で描画され、`magnification`/`dilution_amount` の disabled/readonly 状態がJSの状態遷移と初期表示で一致するよう修正

## Test plan
- [x] 回帰テストを追加(`test/controllers/works/chemicals_controller_test.rb`)、既存テストと合わせて全件成功を確認
- [x] E2Eで実際の画面操作(無への切り替え→保存→再表示)を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)