### PR TITLE
#901 phase.16 育苗・水稲・乾燥関連を組織スコープ化

### DIFF
--- a/app/controllers/dryings_controller.rb
+++ b/app/controllers/dryings_controller.rb
@@ -27,6 +27,7 @@ class DryingsController < ApplicationController
     @drying = Drying.new(drying_params)
     return to_error_path unless Home.for_organization(current_organization).exists?(id: @drying.home_id)
 
+    validate_drying_lands!
     if @drying.save
       redirect_to dryings_path
     else
@@ -35,6 +36,7 @@ class DryingsController < ApplicationController
   end
 
   def update
+    validate_drying_lands!
     if @drying.update(drying_params)
       redirect_to drying_path(@drying.home)
     else
@@ -106,5 +108,12 @@ class DryingsController < ApplicationController
     @drying.drying_moths.build(default_moths) if @drying.drying_moths.empty?
     @drying.drying_lands.build(default_lands) if @drying.drying_lands.empty?
     @drying.build_adjustment unless @drying.adjustment
+  end
+
+  def validate_drying_lands!
+    attributes = drying_params[:drying_lands_attributes]
+    attributes = attributes.values if attributes.respond_to?(:values)
+    ids = Array(attributes).filter_map { |values| values[:land_id].presence }
+    Land.for_organization(current_organization).find(ids) if ids.present?
   end
 end

--- a/app/controllers/fixes_controller.rb
+++ b/app/controllers/fixes_controller.rb
@@ -18,7 +18,7 @@ class FixesController < ApplicationController
     case @fixed_at.month
     when SHOW1_MONTH
       @lands = Land.for_organization(current_organization).for_finance1.group(:manager_id).sum(:area)
-      @seedling_homes = SeedlingHome.usual(current_term)
+      @seedling_homes = SeedlingHome.usual(current_term, current_organization)
       render action: :show1
     when SHOW2_MONTH
       @lands1 = Land.for_organization(current_organization).for_finance1.group(:manager_id).sum(:area)

--- a/app/controllers/harvest_rices_controller.rb
+++ b/app/controllers/harvest_rices_controller.rb
@@ -3,7 +3,7 @@ class HarvestRicesController < ApplicationController
   helper DryingsHelper
 
   def index
-    @dryings = Drying.for_harvest(current_term)
+    @dryings = Drying.for_harvest(current_term, current_organization)
     @work_type_totals, @carried_on_totals, @areas = calc_totals(@dryings)
   end
 

--- a/app/controllers/personal_informations/seedlings_controller.rb
+++ b/app/controllers/personal_informations/seedlings_controller.rb
@@ -1,5 +1,5 @@
 class PersonalInformations::SeedlingsController < PersonalInformationsController
   def index
-    @seedling_homes = SeedlingHome.usual(@current_user.term).by_home(@worker.home)
+    @seedling_homes = SeedlingHome.usual(@current_user.term, current_organization).by_home(@worker.home)
   end
 end

--- a/app/controllers/plans/lands_controller.rb
+++ b/app/controllers/plans/lands_controller.rb
@@ -18,7 +18,7 @@ class Plans::LandsController < PlansController
   end
 
   def create
-    PlanLand.create_all(current_user.id, plan_term, params["land"])
+    PlanLand.create_all(current_user, plan_term, params["land"], current_organization)
     redirect_to new_plans_land_path(mode: params[:mode])
   end
 

--- a/app/controllers/seedling_costs_controller.rb
+++ b/app/controllers/seedling_costs_controller.rb
@@ -5,12 +5,12 @@ class SeedlingCostsController < ApplicationController
   def index
     @work_types = WorkType.land
     @seedlings = Seedling.usual(current_term, @work_types)
-    @seedling_quantities = SeedlingHome.total(@seedlings)
+    @seedling_quantities = SeedlingHome.total(@seedlings, current_organization)
     @lands = LandCost.total(Time.zone.today, current_organization)
   end
 
   def edit
-    @homes = Home.for_seedling
+    @homes = Home.for_organization(current_organization).for_seedling
     @seedling.seedling_homes.build
   end
 
@@ -29,6 +29,7 @@ class SeedlingCostsController < ApplicationController
   end
 
   def update
+    validate_seedling_homes!
     if @seedling.update(seedling_home_params)
       redirect_to edit_seedling_cost_path(seedling_id: @seedling.id)
     else
@@ -54,5 +55,15 @@ class SeedlingCostsController < ApplicationController
     params
       .require(:seedling)
       .permit(seedling_homes_attributes: [:id, :home_id, :sowed_on, :quantity, :_destroy])
+  end
+
+  def validate_seedling_homes!
+    attributes = seedling_home_params[:seedling_homes_attributes]
+    attributes = attributes.values if attributes.respond_to?(:values)
+    attributes = Array(attributes)
+    home_ids = attributes.filter_map { |values| values[:home_id].presence }
+    seedling_home_ids = attributes.filter_map { |values| values[:id].presence }
+    Home.for_organization(current_organization).find(home_ids) if home_ids.present?
+    SeedlingHome.for_organization(current_organization).find(seedling_home_ids) if seedling_home_ids.present?
   end
 end

--- a/app/controllers/seedling_results_controller.rb
+++ b/app/controllers/seedling_results_controller.rb
@@ -5,7 +5,7 @@ class SeedlingResultsController < ApplicationController
   before_action :set_works, only: [:edit, :update]
 
   def index
-    @seedling_homes = SeedlingHome.usual(current_term)
+    @seedling_homes = SeedlingHome.usual(current_term, current_organization)
     @seedling_result_quantities = SeedlingResult.total(@seedling_homes)
   end
 
@@ -14,6 +14,7 @@ class SeedlingResultsController < ApplicationController
   end
 
   def update
+    validate_work_results!
     if @seedling_home.update(seedling_results_params)
       redirect_to edit_seedling_result_path(seedling_home_id: @seedling_home.id)
     else
@@ -33,7 +34,7 @@ class SeedlingResultsController < ApplicationController
   private
 
   def set_seedling_home
-    @seedling_home = SeedlingHome.joins(:home).where(homes: { organization_id: current_organization.id }).find(params[:seedling_home_id])
+    @seedling_home = SeedlingHome.for_organization(current_organization).find(params[:seedling_home_id])
   end
 
   def set_works
@@ -58,5 +59,12 @@ class SeedlingResultsController < ApplicationController
           ]]
         ]
       )
+  end
+
+  def validate_work_results!
+    attributes = seedling_results_params[:seedling_results_attributes]
+    attributes = attributes.values if attributes.respond_to?(:values)
+    ids = Array(attributes).filter_map { |values| values[:work_result_id].presence }
+    WorkResult.for_organization(current_organization).find(ids) if ids.present?
   end
 end

--- a/app/controllers/total_dryings_controller.rb
+++ b/app/controllers/total_dryings_controller.rb
@@ -4,7 +4,7 @@ class TotalDryingsController < ApplicationController
 
   def index
     @dryings = {}
-    Home.for_drying.each do |home|
+    Home.for_organization(current_organization).for_drying.each do |home|
       @dryings[home] = DryingDecorator.decorate_collection(Drying.by_home(current_term, home))
     end
     respond_to do |format|

--- a/app/controllers/total_seedlings_controller.rb
+++ b/app/controllers/total_seedlings_controller.rb
@@ -4,7 +4,7 @@ class TotalSeedlingsController < ApplicationController
 
   def index
     @seedling_price = current_system.seedling_price
-    @seedling_homes = SeedlingHome.usual(current_term)
+    @seedling_homes = SeedlingHome.usual(current_term, current_organization)
     @seedling_result_quantities = SeedlingResult.total(@seedling_homes)
 
     respond_to do |format|

--- a/app/models/drying.rb
+++ b/app/models/drying.rb
@@ -53,7 +53,7 @@ class Drying < ApplicationRecord
   scope :for_harvest, lambda { |term, organization = nil|
     base = joins(:home, :work_type)
       .where(dryings: { term: term })
-    base = base.for_organization(organization) if organization
+    base = base.merge(Home.for_organization(organization)) if organization
     base
       .order(Arel.sql("work_types.display_order, dryings.carried_on, homes.drying_order, dryings.id"))
   }

--- a/app/models/drying.rb
+++ b/app/models/drying.rb
@@ -50,9 +50,11 @@ class Drying < ApplicationRecord
       .order(:carried_on).order(:id)
   }
 
-  scope :for_harvest, lambda { |term|
-    joins(:home, :work_type)
+  scope :for_harvest, lambda { |term, organization = nil|
+    base = joins(:home, :work_type)
       .where(dryings: { term: term })
+    base = base.for_organization(organization) if organization
+    base
       .order(Arel.sql("work_types.display_order, dryings.carried_on, homes.drying_order, dryings.id"))
   }
 

--- a/app/models/drying_land.rb
+++ b/app/models/drying_land.rb
@@ -20,4 +20,19 @@ class DryingLand < ApplicationRecord
   belongs_to :land
 
   MAX_COUNT = 3
+
+  scope :for_organization, lambda { |organization|
+    joins(:drying).merge(Drying.for_organization(organization))
+  }
+
+  validate :land_belongs_to_drying_organization
+
+  private
+
+  def land_belongs_to_drying_organization
+    return if land.blank? || drying&.home.blank?
+    return if land.organization_id == drying.home.organization_id
+
+    errors.add(:land_id, "は乾燥担当世帯と同じ組織の土地を指定してください。")
+  end
 end

--- a/app/models/drying_moth.rb
+++ b/app/models/drying_moth.rb
@@ -21,4 +21,8 @@ class DryingMoth < ApplicationRecord
   belongs_to :drying
 
   MAX_COUNT = 5
+
+  scope :for_organization, lambda { |organization|
+    joins(:drying).merge(Drying.for_organization(organization))
+  }
 end

--- a/app/models/owned_rice.rb
+++ b/app/models/owned_rice.rb
@@ -43,7 +43,7 @@ class OwnedRice < ApplicationRecord
       .where(owned_rice_prices: { term: term })
       .where("owned_rices.owned_count > 0")
       .order("homes.finance_order, homes.id, owned_rice_prices.display_order, owned_rice_prices.id")
-    organization ? base.for_organization(organization) : base
+    organization ? base.merge(Home.for_organization(organization)) : base
   }
 
   def self.regist(id, params, organization = nil)

--- a/app/models/owned_rice.rb
+++ b/app/models/owned_rice.rb
@@ -20,17 +20,19 @@ class OwnedRice < ApplicationRecord
 
   OWNED_RICE_COUNT = 2 # 10a当たりの保有米数
 
+  scope :for_organization, ->(organization) { joins(:home).merge(Home.for_organization(organization)) }
+
   scope :usual, lambda { |term, organization = nil|
     base = joins(:owned_rice_price)
       .where(owned_rice_prices: { term: term })
-    organization ? base.joins(:home).where(homes: { organization_id: organization.is_a?(Organization) ? organization.id : organization }) : base
+    organization ? base.for_organization(organization) : base
   }
 
   scope :by_home, lambda { |term, home_id, organization = nil|
     base = joins(:owned_rice_price)
       .where(["owned_rice_prices.term = ? AND owned_rices.home_id = ?", term, home_id])
       .order("owned_rice_prices.display_order, owned_rice_prices.id")
-    organization ? base.joins(:home).where(homes: { organization_id: organization.is_a?(Organization) ? organization.id : organization }) : base
+    organization ? base.for_organization(organization) : base
   }
 
   scope :available, -> { where("owned_rices.owned_count > 0") }
@@ -41,20 +43,18 @@ class OwnedRice < ApplicationRecord
       .where(owned_rice_prices: { term: term })
       .where("owned_rices.owned_count > 0")
       .order("homes.finance_order, homes.id, owned_rice_prices.display_order, owned_rice_prices.id")
-    organization ? base.where(homes: { organization_id: organization.is_a?(Organization) ? organization.id : organization }) : base
+    organization ? base.for_organization(organization) : base
   }
 
   def self.regist(id, params, organization = nil)
-    owned_rice = if id && organization
-                   OwnedRice.joins(:home).where(homes: { organization_id: organization.is_a?(Organization) ? organization.id : organization }).find_by(id: id)
-                 elsif id
+    home = organization ? Home.for_organization(organization).find(params[:home_id]) : Home.find(params[:home_id])
+    owned_rice = if id.present? && organization
+                   for_organization(organization).find(id)
+                 elsif id.present?
                    OwnedRice.find_by(id: id)
                  end
-    if owned_rice
-      owned_rice.update(params)
-    else
-      OwnedRice.create(params)
-    end
+    attributes = params.except(:home_id).merge(home: home)
+    owned_rice ? owned_rice.update(attributes) : create(attributes)
   end
 
   def owned_price

--- a/app/models/plan_land.rb
+++ b/app/models/plan_land.rb
@@ -19,12 +19,20 @@ class PlanLand < ApplicationRecord
   belongs_to :work_type
   belongs_to :user
 
+  scope :for_organization, ->(organization) { joins(:land).merge(Land.for_organization(organization)) }
   scope :usual, ->(user, term) { where(user_id: user.id, term: term).joins(:land).joins(:work_type).order("work_types.display_order, plan_lands.work_type_id, lands.place") }
 
-  def self.create_all(user_id, term, params)
-    PlanLand.where(user_id: user_id, term: term).delete_all
-    params.each do |param|
-      PlanLand.create(user_id: user_id, term: term, land_id: param[0], work_type_id: param[1]) if param[1].present?
+  validate :land_belongs_to_user_organization
+
+  def self.create_all(user, term, params, organization)
+    transaction do
+      where(user_id: user.id, term: term).delete_all
+      params.each do |land_id, work_type_id|
+        next if work_type_id.blank?
+
+        land = Land.for_organization(organization).find(land_id)
+        create!(user: user, term: term, land: land, work_type_id: work_type_id)
+      end
     end
   end
 
@@ -34,5 +42,13 @@ class PlanLand < ApplicationRecord
       land_cost = land.cost(target)
       PlanLand.create(user_id: user_id, term: term, land_id: land.id, work_type_id: land_cost.work_type_id) if land_cost
     end
+  end
+
+  private
+
+  def land_belongs_to_user_organization
+    return if land.blank? || user.blank? || land.organization_id == user.organization_id
+
+    errors.add(:land_id, "は利用者と同じ組織の土地を指定してください。")
   end
 end

--- a/app/models/plan_seedling.rb
+++ b/app/models/plan_seedling.rb
@@ -40,7 +40,7 @@ class PlanSeedling < ApplicationRecord
         end
       end
       base = joins(:home).where(homes: { seedling_order: nil })
-      base = base.for_organization(organization) if organization
+      base = base.merge(Home.for_organization(organization)) if organization
       base.destroy_all
     end
   end

--- a/app/models/plan_seedling.rb
+++ b/app/models/plan_seedling.rb
@@ -18,26 +18,31 @@ class PlanSeedling < ApplicationRecord
   belongs_to :home
   belongs_to :plan, class_name: "PlanWorkType", foreign_key: "plan_work_type_id"
 
-  def self.usual
+  scope :for_organization, ->(organization) { joins(:home).merge(Home.for_organization(organization)) }
+
+  def self.usual(organization = nil)
     results = Hash.new { |h, k| h[k] = {} }
-    PlanSeedling.find_each do |seedling|
+    seedlings = organization ? for_organization(organization) : all
+    seedlings.find_each do |seedling|
       results[seedling.home_id][seedling.plan_work_type_id] = seedling
     end
     results
   end
 
-  def self.create_all(params)
-    params.each do |hid, param|
-      param.each do |pid, q|
-        pl = PlanSeedling.find_by(home_id: hid, plan_work_type_id: pid)
-        if pl.present?
+  def self.create_all(params, organization = nil)
+    transaction do
+      params.each do |hid, param|
+        home = organization ? Home.for_organization(organization).find(hid) : Home.find(hid)
+        param.each do |pid, q|
+          pl = find_or_initialize_by(home: home, plan_work_type_id: pid)
           pl.quantity = q[:quantity]
-        else
-          PlanSeedling.create(home_id: hid, plan_work_type_id: pid, quantity: q[:quantity])
+          pl.save!
         end
       end
+      base = joins(:home).where(homes: { seedling_order: nil })
+      base = base.for_organization(organization) if organization
+      base.destroy_all
     end
-    PlanSeedling.joins(:home).where(homes: { seedling_order: nil }).destroy_all
   end
 
   def seeds

--- a/app/models/seedling_home.rb
+++ b/app/models/seedling_home.rb
@@ -18,10 +18,17 @@ class SeedlingHome < ApplicationRecord
 
   accepts_nested_attributes_for :seedling_results, allow_destroy: true, reject_if: :reject_seedling_results
 
-  scope :total, ->(seedlings) { where(seedling_id: seedlings.ids).group(:seedling_id).sum(:quantity) }
-  scope :usual, lambda { |term|
-    includes({ seedling: :work_type }, :home)
+  scope :for_organization, ->(organization) { joins(:home).merge(Home.for_organization(organization)) }
+  scope :total, lambda { |seedlings, organization = nil|
+    base = where(seedling_id: seedlings.ids)
+    base = base.for_organization(organization) if organization
+    base.group(:seedling_id).sum(:quantity)
+  }
+  scope :usual, lambda { |term, organization = nil|
+    base = includes({ seedling: :work_type }, :home)
       .where(seedlings: { term: term })
+    base = base.for_organization(organization) if organization
+    base
       .order("homes.display_order, homes.id, seedling_homes.sowed_on, work_types.display_order, work_types.id")
   }
   scope :by_home, ->(home) { where(home_id: home.id) }

--- a/app/models/seedling_result.rb
+++ b/app/models/seedling_result.rb
@@ -15,6 +15,10 @@ class SeedlingResult < ApplicationRecord
   belongs_to :seedling_home
   belongs_to :work_result
 
+  scope :for_organization, lambda { |organization|
+    joins(:seedling_home).merge(SeedlingHome.for_organization(organization))
+  }
+
   scope :total, ->(seedling_homes) { where(seedling_home_id: seedling_homes.pluck(:id)).group(:seedling_home_id).sum(:quantity) }
   scope :for_seedling_use, lambda {
     joins(work_result: :work)
@@ -29,6 +33,8 @@ class SeedlingResult < ApplicationRecord
       .sum(:quantity)
   }
 
+  validate :work_result_belongs_to_same_organization
+
   def work_id
     work_result&.work_id
   end
@@ -36,5 +42,14 @@ class SeedlingResult < ApplicationRecord
   def self.dispose?(seedling_home, worked_at)
     joins(work_result: :work)
       .exists?(["seedling_results.seedling_home_id = ? AND works.worked_at = ? AND disposal_flag = TRUE", seedling_home.id, worked_at])
+  end
+
+  private
+
+  def work_result_belongs_to_same_organization
+    return if seedling_home&.home.blank? || work_result&.work.blank?
+    return if seedling_home.home.organization_id == work_result.work.organization_id
+
+    errors.add(:work_result_id, "は育苗担当世帯と同じ組織の作業実績を指定してください。")
   end
 end

--- a/app/models/zengin_payment_batch.rb
+++ b/app/models/zengin_payment_batch.rb
@@ -147,7 +147,7 @@ class ZenginPaymentBatch < ApplicationRecord
     seedling_price = seedling_price.to_i
     seedling_homes = SeedlingHome.usual(term, organization_id)
       .joins(home: :section)
-      .where(homes: { organization_id: organization_id, member_flag: true }, sections: { work_flag: true })
+      .where(homes: { member_flag: true }, sections: { work_flag: true })
 
     transaction do
       replace_generated_seedling_fee_details!(seedling_homes, seedling_price)

--- a/app/models/zengin_payment_batch.rb
+++ b/app/models/zengin_payment_batch.rb
@@ -145,7 +145,7 @@ class ZenginPaymentBatch < ApplicationRecord
 
   def import_seedling_fee!(term:, seedling_price:)
     seedling_price = seedling_price.to_i
-    seedling_homes = SeedlingHome.usual(term)
+    seedling_homes = SeedlingHome.usual(term, organization_id)
       .joins(home: :section)
       .where(homes: { organization_id: organization_id, member_flag: true }, sections: { work_flag: true })
 

--- a/test/controllers/phase16_organization_scope_test.rb
+++ b/test/controllers/phase16_organization_scope_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+class Phase16OrganizationScopeControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:users1)
+    @other_home = homes(:home_other_org)
+    @other_land = lands(:land_other_org)
+    login_as(@user)
+  end
+
+  test "育苗一覧と集計に他組織の担当世帯を含めない" do
+    SeedlingHome.create!(
+      seedling: seedlings(:seedling1), home: @other_home, quantity: 10, sowed_on: Date.new(2015, 5, 1)
+    )
+
+    get seedling_results_path
+    assert_response :success
+    assert_not_includes response.body, @other_home.name
+
+    get total_seedlings_path
+    assert_response :success
+    assert_not_includes response.body, @other_home.name
+  end
+
+  test "育苗担当に他組織の世帯を登録できない" do
+    attributes = { seedling_homes_attributes: [{ home_id: @other_home.id, quantity: 10 }] }
+
+    assert_no_difference("SeedlingHome.count") do
+      patch seedling_cost_path(seedling_id: seedlings(:seedling1).id), params: { seedling: attributes }
+    end
+    assert_response :not_found
+  end
+
+  test "育苗結果に他組織の作業実績を登録できない" do
+    attributes = {
+      seedling_results_attributes: [{ work_result_id: work_results(:work_result_other_org).id, quantity: 1 }]
+    }
+
+    assert_no_difference("SeedlingResult.count") do
+      patch seedling_result_path(seedling_home_id: seedling_homes(:seedling_home1).id),
+            params: { seedling_home: attributes }
+    end
+    assert_response :not_found
+  end
+
+  test "保有米の空IDは新規登録として扱う" do
+    attributes = {
+      owned_rice_prices(:owned_rice_price1).id => {
+        id: "", home_id: homes(:home2).id,
+        owned_rice_price_id: owned_rice_prices(:owned_rice_price1).id, owned_count: 2
+      }
+    }
+
+    assert_difference("OwnedRice.count") do
+      patch owned_rice_path(homes(:home2).id), params: { owned_rices: attributes }
+    end
+    assert_redirected_to owned_rices_path
+  end
+
+  test "保有米更新で他組織のレコードを変更できない" do
+    owned_rice = OwnedRice.create!(
+      home: @other_home, owned_rice_price: owned_rice_prices(:owned_rice_price1), owned_count: 1
+    )
+    attributes = {
+      owned_rice.id => {
+        id: owned_rice.id, home_id: homes(:home1).id,
+        owned_rice_price_id: owned_rice_prices(:owned_rice_price1).id, owned_count: 99
+      }
+    }
+
+    patch owned_rice_path(homes(:home1).id), params: { owned_rices: attributes }
+
+    assert_response :not_found
+    assert_equal 1, owned_rice.reload.owned_count
+  end
+
+  test "作付計画に他組織の土地を登録できない" do
+    login_as(users(:user_manager))
+    mode = Plans::LandsController::TERM_MODES[:next]
+
+    travel_to(Date.new(2015, 1, 1)) do
+      assert_no_difference("PlanLand.count") do
+        post plans_lands_path(mode: mode), params: { land: { @other_land.id => work_types(:work_types1).id } }
+      end
+      assert_response :not_found
+    end
+  end
+
+  test "乾燥調整に他組織の土地を登録できない" do
+    attributes = { drying_lands_attributes: [{ land_id: @other_land.id, display_order: 1 }] }
+
+    assert_no_difference("DryingLand.count") do
+      patch drying_path(dryings(:drying1)), params: { drying: attributes }
+    end
+    assert_response :not_found
+  end
+
+  test "乾燥集計に他組織の世帯を含めない" do
+    @other_home.update!(drying_order: 999)
+
+    get total_dryings_path
+
+    assert_response :success
+    assert_not_includes response.body, @other_home.name
+  end
+end

--- a/test/models/phase16_organization_scope_test.rb
+++ b/test/models/phase16_organization_scope_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+class Phase16OrganizationScopeTest < ActiveSupport::TestCase
+  setup do
+    @organization = organizations(:org)
+    @other_organization = organizations(:org2)
+    @other_home = homes(:home_other_org)
+    @other_land = lands(:land_other_org)
+    @other_seedling_home = SeedlingHome.create!(
+      seedling: seedlings(:seedling1), home: @other_home, quantity: 10, sowed_on: Date.new(2015, 5, 1)
+    )
+    @other_seedling_result = SeedlingResult.create!(
+      seedling_home: @other_seedling_home, work_result: work_results(:work_result_other_org), quantity: 5
+    )
+    @other_owned_rice = OwnedRice.create!(
+      home: @other_home, owned_rice_price: owned_rice_prices(:owned_rice_price1), owned_count: 1
+    )
+    @other_plan_seedling = PlanSeedling.create!(
+      home: @other_home, plan: plan_work_types(:plan_work_type_kinu), quantity: 1
+    )
+    @other_plan_land = PlanLand.create!(
+      user: users(:user_admin_org2), land: @other_land, work_type: work_types(:work_types1), term: 2015
+    )
+    @other_drying = Drying.create!(
+      home: @other_home, work_type: work_types(:work_types1), term: 2015,
+      carried_on: Date.new(2015, 9, 30), drying_type_id: :country
+    )
+    @other_drying_land = DryingLand.create!(drying: @other_drying, land: @other_land, display_order: 1)
+    @other_drying_moth = DryingMoth.create!(drying: @other_drying, moth_count: 1)
+  end
+
+  test "親レコードの組織で各対象を絞り込む" do
+    assert_scoped SeedlingHome, @other_seedling_home
+    assert_scoped SeedlingResult, @other_seedling_result
+    assert_scoped OwnedRice, @other_owned_rice
+    assert_scoped PlanSeedling, @other_plan_seedling
+    assert_scoped PlanLand, @other_plan_land
+    assert_scoped DryingLand, @other_drying_land
+    assert_scoped DryingMoth, @other_drying_moth
+    assert_includes Drying.for_harvest(2015, @other_organization), @other_drying
+    assert_not_includes Drying.for_harvest(2015, @organization), @other_drying
+  end
+
+  test "育苗結果には育苗担当世帯と同じ組織の作業実績だけを指定できる" do
+    result = SeedlingResult.new(
+      seedling_home: seedling_homes(:seedling_home1),
+      work_result: work_results(:work_result_other_org),
+      quantity: 1
+    )
+
+    assert_not result.valid?
+    assert result.errors.added?(:work_result_id, "は育苗担当世帯と同じ組織の作業実績を指定してください。")
+  end
+
+  test "保有米登録では他組織の世帯を指定できない" do
+    assert_raises(ActiveRecord::RecordNotFound) do
+      OwnedRice.regist(
+        owned_rices(:owned_rice1).id,
+        { home_id: @other_home.id, owned_rice_price_id: owned_rice_prices(:owned_rice_price1).id, owned_count: 1 },
+        @organization
+      )
+    end
+  end
+
+  test "育苗計画の一括登録では他組織の世帯を指定できない" do
+    params = { @other_home.id => { plan_work_types(:plan_work_type_kinu).id => { quantity: 1 } } }
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      PlanSeedling.create_all(params, @organization)
+    end
+  end
+
+  test "作付計画には利用者と同じ組織の土地だけを指定できる" do
+    plan_land = PlanLand.new(
+      user: users(:user_manager), land: @other_land, work_type: work_types(:work_types1), term: 2015
+    )
+
+    assert_not plan_land.valid?
+    assert plan_land.errors.added?(:land_id, "は利用者と同じ組織の土地を指定してください。")
+  end
+
+  test "乾燥場所には担当世帯と同じ組織の土地だけを指定できる" do
+    drying_land = DryingLand.new(drying: dryings(:drying1), land: @other_land, display_order: 1)
+
+    assert_not drying_land.valid?
+    assert drying_land.errors.added?(:land_id, "は乾燥担当世帯と同じ組織の土地を指定してください。")
+  end
+
+  private
+
+  def assert_scoped(model, record)
+    conditions = if model.primary_key
+                   Array(model.primary_key).zip(Array(record.id)).to_h
+                 else
+                   record.attributes.except("created_at", "updated_at")
+                 end
+    assert model.for_organization(@other_organization).where(conditions).exists?, model.name
+    assert_not model.for_organization(@organization).where(conditions).exists?, model.name
+  end
+end


### PR DESCRIPTION
phase.16（育苗・水稲・乾燥関連）の組織スコープ対応です。

コミット: 5ebd66ac (`#901 phase.16 育苗・水稲・乾燥関連を組織スコープ化`)

主な対応:
- `seedling_homes/results`, `owned_rices`, `plan_seedlings/lands`, `drying_lands/moths` に親レコード経由の組織スコープを追加
- 育苗・乾燥の一覧／集計／全銀支払処理を現在組織で絞り込み
- 他組織の世帯・土地・作業実績をネスト更新や一括登録で指定できないよう検証を追加
- モデル／コントローラの組織分離回帰テストを追加

確認結果:
- `bin/rails test`: 1093 runs, 4607 assertions, 0 failures, 0 errors, 0 skips
- 新規テスト2ファイルの RuboCop: offenses なし
- `git diff --check`: 問題なし