### PR TITLE
#10 phase.4 作業予定に年度名を表示

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,7 +1,7 @@
 class SchedulesController < ApplicationController
   include ReturnToIndex
 
-  ScheduleTermOption = Struct.new(:term, :start_date, :end_date, :disabled, keyword_init: true) do
+  ScheduleTermOption = Struct.new(:term, :term_name, :start_date, :end_date, :disabled, keyword_init: true) do
     def disabled?
       disabled
     end
@@ -131,6 +131,7 @@ class SchedulesController < ApplicationController
     systems.compact.uniq(&:term).sort_by(&:term).map do |system|
       ScheduleTermOption.new(
         term: system.term,
+        term_name: system.term_name,
         start_date: system.start_date,
         end_date: system.end_date,
         disabled: false
@@ -193,10 +194,9 @@ class SchedulesController < ApplicationController
   end
 
   def schedule_term_label(option)
-    return "今年度" if option.term == current_term
-    return "翌年度" if option.term == next_term
+    return option.term_name if option.term_name.present?
 
-    "#{option.term}年度"
+    "翌年度"
   end
   helper_method :schedule_term_label
 

--- a/test/controllers/schedules_controller_test.rb
+++ b/test/controllers/schedules_controller_test.rb
@@ -32,6 +32,16 @@ class SchedulesControllerTest < ActionDispatch::IntegrationTest
     assert_select "input#schedule_work_type_term_2016[data-start-date=?][data-end-date=?]", systems(:s2016).start_date.to_s, systems(:s2016).end_date.to_s
   end
 
+  test "作業予定登録は年度名を表示する" do
+    systems(:s2015).update!(term_name: "第15期")
+    systems(:s2016).update!(term_name: "第16期")
+
+    get new_schedule_path
+    assert_response :success
+    assert_select "label[for=schedule_work_type_term_2015]", "第15期"
+    assert_select "label[for=schedule_work_type_term_2016]", "第16期"
+  end
+
   test "作業予定登録表示は作業分類が存在しない年度でも表示できる" do
     WorkTypeTerm.where(term: @user.term).delete_all
 


### PR DESCRIPTION
## Phase.4 完了

作業予定登録画面の年度選択表示を、数値の `term` や相対的な年度表現ではなく `System#term_name` を参照する形式へ変更しました。

- `ScheduleTermOption` に `term_name` を追加
- 作成済みの当期・次期などは各 `System#term_name` を表示
- 次期の `System` が未作成で選択不可の場合は、従来どおり「翌年度」と表示
- 任意の年度名（例: `第15期` / `第16期`）が表示される回帰テストを追加

Commit: `afb4b1c7` (`#10 phase.4 作業予定に年度名を表示`)

確認結果:
- `bin/rails test test/controllers/schedules_controller_test.rb`
- 19 runs / 89 assertions / 0 failures / 0 errors
- `bin/rails test`
- 1094 runs / 4612 assertions / 0 failures / 0 errors
- `git diff --check`: 問題なし