### PR TITLE
#1113 薬剤登録画面: 希釈(ℓ/倍)相互変換の不具合修正と選択肢表示順の変更

### DIFF
--- a/app/javascript/pages/edit-chemicals.js
+++ b/app/javascript/pages/edit-chemicals.js
@@ -9,7 +9,8 @@ export const init = () => {
       const group = event.target.dataset.group;
       const id = event.target.dataset.id;
       const unitScale = new Decimal(event.target.dataset.unit);
-      const quantity = new Decimal(document.querySelector(`input[name='chemicals[${id}][${group}][quantity]']`).value);
+      const multiplier = new Decimal(event.target.dataset.multiplier);
+      const quantity = new Decimal(document.querySelector(`input[name='chemicals[${id}][${group}][quantity]']`).value).mul(multiplier);
       const mag = new Decimal(document.querySelector(`input[name='chemicals[${id}][${group}][magnification]']`).value);
       const dil = document.querySelector(`input[name='chemicals[${id}][${group}][dilution_amount]']`);
 
@@ -21,7 +22,8 @@ export const init = () => {
       const group = event.target.dataset.group;
       const id = event.target.dataset.id;
       const unitScale = new Decimal(event.target.dataset.unit);
-      const quantity = new Decimal(document.querySelector(`input[name='chemicals[${id}][${group}][quantity]']`).value);
+      const multiplier = new Decimal(event.target.dataset.multiplier);
+      const quantity = new Decimal(document.querySelector(`input[name='chemicals[${id}][${group}][quantity]']`).value).mul(multiplier);
       const dil = new Decimal(document.querySelector(`input[name='chemicals[${id}][${group}][dilution_amount]']`).value);
       const mag = document.querySelector(`input[name='chemicals[${id}][${group}][magnification]']`);
 

--- a/app/javascript/pages/edit-chemicals.js
+++ b/app/javascript/pages/edit-chemicals.js
@@ -27,7 +27,7 @@ export const init = () => {
       const dil = new Decimal(document.querySelector(`input[name='chemicals[${id}][${group}][dilution_amount]']`).value);
       const mag = document.querySelector(`input[name='chemicals[${id}][${group}][magnification]']`);
 
-      mag.value = dil.mul(unitScale).div(quantity).toFixed(1);
+      mag.value = quantity.isZero() ? "" : dil.mul(unitScale).div(quantity).toFixed(1);
     });
   });
   document.querySelectorAll("input[name$='quantity]']").forEach((element) => {

--- a/app/models/chemical.rb
+++ b/app/models/chemical.rb
@@ -154,6 +154,20 @@ class Chemical < ApplicationRecord
     Unit.find_by(code: unit).scale
   end
 
+  # 使用量の単位(unit)が本/袋/缶など個数単位(scale 0)の場合、そのままでは希釈計算(cc/g前提)が
+  # 成立しないため、base_quantity(1個あたりの内容量=cc/g相当)を掛けて実量に変換した上でscaleを補う
+  def dilution_scale
+    unit_scale.positive? ? unit_scale : 1000
+  end
+
+  def dilution_multiplier
+    unit_scale.positive? ? 1 : base_quantity
+  end
+
+  def dilution_quantity(quantity)
+    quantity * dilution_multiplier
+  end
+
   def unit_name(quantity)
     return base_unit.mega_name if quantity >= 1_000_000
     return base_unit.kilo_name if quantity >= 1_000

--- a/app/models/chemical.rb
+++ b/app/models/chemical.rb
@@ -164,6 +164,12 @@ class Chemical < ApplicationRecord
     unit_scale.positive? ? 1 : base_quantity
   end
 
+  # 個数単位でbase_quantity(1個あたりの内容量)が未設定/0の薬剤は実量に換算できないため、
+  # 呼び出し側はこれがfalseの場合、希釈計算をせずnil等にフォールバックすること
+  def dilution_available?
+    dilution_multiplier.positive?
+  end
+
   def dilution_quantity(quantity)
     quantity * dilution_multiplier
   end

--- a/app/models/work_chemical.rb
+++ b/app/models/work_chemical.rb
@@ -89,9 +89,9 @@ class WorkChemical < ApplicationRecord
   end
 
   def dilution_amount
-    return nil if dilution_none?
+    return nil if dilution_none? || magnification.blank?
 
-    dilution? ? (chemical.dilution_quantity(quantity) * magnification / chemical.dilution_scale).round(1) : quantity
+    (chemical.dilution_quantity(quantity) * magnification / chemical.dilution_scale).round(1)
   end
 
   def dilution?

--- a/app/models/work_chemical.rb
+++ b/app/models/work_chemical.rb
@@ -89,7 +89,7 @@ class WorkChemical < ApplicationRecord
   end
 
   def dilution_amount
-    return nil if dilution_none? || magnification.blank?
+    return nil if dilution_none? || magnification.blank? || !chemical.dilution_available?
 
     (chemical.dilution_quantity(quantity) * magnification / chemical.dilution_scale).round(1)
   end

--- a/app/models/work_chemical.rb
+++ b/app/models/work_chemical.rb
@@ -91,7 +91,7 @@ class WorkChemical < ApplicationRecord
   def dilution_amount
     return nil if dilution_none?
 
-    dilution? && chemical.unit_scale.positive? ? (quantity * magnification / chemical.unit_scale).round(1) : quantity
+    dilution? ? (chemical.dilution_quantity(quantity) * magnification / chemical.dilution_scale).round(1) : quantity
   end
 
   def dilution?

--- a/app/views/works/chemicals/new.html.erb
+++ b/app/views/works/chemicals/new.html.erb
@@ -95,14 +95,14 @@
                 (effective_dilution_id == Dilution::NONE.id ? nil : work_chemical&.magnification),
                 {disabled: effective_dilution_id == Dilution::NONE.id, readonly: effective_dilution_id != Dilution::MAG.id,
                 min: 0, max: 9999.9, step: 0.1, class: "form-control form-control-sm narrow",
-                data: {id: chemical.id, group: index + 1, unit: chemical.unit_scale}} %>
+                data: {id: chemical.id, group: index + 1, unit: chemical.dilution_scale, multiplier: chemical.dilution_multiplier}} %>
             </td>
             <td class="col-data" data-index="<%= index %>" style="display:none;">
               <%= number_field_tag "chemicals[#{chemical.id}][#{index + 1}][dilution_amount]",
                 (effective_dilution_id == Dilution::NONE.id ? nil : work_chemical&.dilution_amount),
                 {disabled: effective_dilution_id == Dilution::NONE.id, readonly: effective_dilution_id != Dilution::L.id,
                 min: 0, max: 9999.9, step: 0.1, class: "form-control form-control-sm narrow",
-                data: {id: chemical.id, group: index + 1, unit: chemical.unit_scale}} %>
+                data: {id: chemical.id, group: index + 1, unit: chemical.dilution_scale, multiplier: chemical.dilution_multiplier}} %>
             </td>
             <td class="col-data numeric" data-index="<%= index %>" style="display:none;" id="chemicals_<%= chemical.id %>_<%= index + 1 %>_quantity10">
               <%= work_chemical&.quantity10 %>

--- a/app/views/works/chemicals/new.html.erb
+++ b/app/views/works/chemicals/new.html.erb
@@ -82,7 +82,7 @@
             <td class="text-center col-data" data-index="<%= index %>" style="display:none; white-space: nowrap;">
               <%= hidden_field_tag "chemicals[#{chemical.id}][#{index + 1}][dilution_id]", Dilution::NONE.id %>
               <div class="form-check-inline">
-                <% Dilution.all.each do |dilution| %>
+                <% [Dilution::NONE, Dilution::MAG, Dilution::L].each do |dilution| %>
                   <%= radio_button_tag "chemicals[#{chemical.id}][#{index + 1}][dilution_id]", dilution.id,
                     effective_dilution_id == dilution.id,
                     {id: "chemicals_#{chemical.id}_#{index + 1}_#{dilution.id}", class: "form-check-input", disabled: !chemical.aqueous_flag, data: {id: chemical.id, group: index + 1}} %>

--- a/test/models/chemical_test.rb
+++ b/test/models/chemical_test.rb
@@ -15,5 +15,11 @@ class ChemicalTest < ActiveSupport::TestCase
     assert_equal 1000, chemical.dilution_scale
     assert_equal 500, chemical.dilution_multiplier
     assert_equal 1000, chemical.dilution_quantity(2)
+    assert chemical.dilution_available?
+  end
+
+  test "dilution_available?(個数単位でbase_quantity未設定/0の場合はfalse)" do
+    assert_not Chemical.new(unit: "本", base_quantity: 0).dilution_available?
+    assert_not Chemical.new(unit: "袋").dilution_available?
   end
 end

--- a/test/models/chemical_test.rb
+++ b/test/models/chemical_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ChemicalTest < ActiveSupport::TestCase
+  test "希釈scale・倍率(使用量単位がcc/gの場合はそのまま)" do
+    chemical = Chemical.new(unit: "cc")
+
+    assert_equal 1000, chemical.dilution_scale
+    assert_equal 1, chemical.dilution_multiplier
+    assert_equal 100, chemical.dilution_quantity(100)
+  end
+
+  test "希釈scale・倍率(使用量単位が本/袋/缶など個数単位の場合はbase_quantityで実量に変換)" do
+    chemical = Chemical.new(unit: "本", base_quantity: 500)
+
+    assert_equal 1000, chemical.dilution_scale
+    assert_equal 500, chemical.dilution_multiplier
+    assert_equal 1000, chemical.dilution_quantity(2)
+  end
+end

--- a/test/models/work_chemical_test.rb
+++ b/test/models/work_chemical_test.rb
@@ -32,4 +32,13 @@ class WorkChemicalTest < ActiveSupport::TestCase
 
     assert_nil work_chemical.dilution_amount
   end
+
+  test "個数単位でbase_quantityが未設定/0のときは実量換算できないためnil" do
+    chemical = Chemical.new(unit: "本", base_quantity: 0)
+    work_chemical = WorkChemical.new(
+      chemical: chemical, dilution_id: Dilution::MAG.id, quantity: 2, magnification: 200
+    )
+
+    assert_nil work_chemical.dilution_amount
+  end
 end

--- a/test/models/work_chemical_test.rb
+++ b/test/models/work_chemical_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class WorkChemicalTest < ActiveSupport::TestCase
+  test "希釈水量(使用量単位がcc/gの場合)" do
+    chemical = Chemical.new(unit: "cc")
+    work_chemical = WorkChemical.new(
+      chemical: chemical, dilution_id: Dilution::MAG.id, quantity: 100, magnification: 200
+    )
+
+    assert_equal 20, work_chemical.dilution_amount
+  end
+
+  test "希釈水量(使用量単位が本など個数単位の場合はbase_quantityで実量換算してから計算)" do
+    chemical = Chemical.new(unit: "本", base_quantity: 500)
+    work_chemical = WorkChemical.new(chemical: chemical, dilution_id: Dilution::MAG.id, quantity: 2, magnification: 200)
+
+    assert_equal 200, work_chemical.dilution_amount
+  end
+
+  test "希釈無のときはnil" do
+    chemical = Chemical.new(unit: "cc")
+    work_chemical = WorkChemical.new(chemical: chemical, dilution_id: Dilution::NONE.id, quantity: 100)
+
+    assert_nil work_chemical.dilution_amount
+  end
+end

--- a/test/models/work_chemical_test.rb
+++ b/test/models/work_chemical_test.rb
@@ -23,4 +23,13 @@ class WorkChemicalTest < ActiveSupport::TestCase
 
     assert_nil work_chemical.dilution_amount
   end
+
+  test "希釈選択済でもmagnification未入力のときは例外にならずnil" do
+    chemical = Chemical.new(unit: "cc")
+    work_chemical = WorkChemical.new(
+      chemical: chemical, dilution_id: Dilution::MAG.id, quantity: 100, magnification: nil
+    )
+
+    assert_nil work_chemical.dilution_amount
+  end
 end

--- a/test/system/work_chemicals_dilution_test.rb
+++ b/test/system/work_chemicals_dilution_test.rb
@@ -9,6 +9,7 @@ class WorkChemicalsDilutionTest < ApplicationSystemTestCase
     fill_in 'login_name', with: @user.login_name
     fill_in 'password', with: 'password'
     click_button '認証する'
+    assert_selector 'a', exact_text: '作業日報管理'
   end
 
   test "希釈相互変換(使用量単位がccの場合)" do
@@ -56,5 +57,26 @@ class WorkChemicalsDilutionTest < ApplicationSystemTestCase
 
     # 2本 x 500ml(base_quantity) = 1000ml を基準に換算されるため 200倍 => 200ℓ
     assert_equal "200.0", dilution_amount_field.value
+  end
+
+  test "希釈相互変換(個数単位でbase_quantity未設定の場合は例外にならず倍率欄が空になる)" do
+    chemical = chemicals(:chemicals2)
+    chemical.update!(aqueous_flag: true, unit: "本", base_quantity: 0)
+
+    visit new_work_use_chemical_path(work_id: @work)
+    assert_selector 'h1', text: '作業日報(薬剤)登録'
+
+    quantity_field = find("input[name='chemicals[#{chemical.id}][1][quantity]']", visible: :all)
+    dilution_amount_field = find("input[name='chemicals[#{chemical.id}][1][dilution_amount]']", visible: :all)
+    magnification_field = find("input[name='chemicals[#{chemical.id}][1][magnification]']", visible: :all)
+
+    choose "chemicals_#{chemical.id}_1_#{Dilution::L.id}", visible: :all
+    quantity_field.set("2")
+    quantity_field.send_keys(:tab)
+    dilution_amount_field.set("100")
+    dilution_amount_field.send_keys(:tab)
+
+    assert_equal "", magnification_field.value
+    assert_selector 'h1', text: '作業日報(薬剤)登録'
   end
 end

--- a/test/system/work_chemicals_dilution_test.rb
+++ b/test/system/work_chemicals_dilution_test.rb
@@ -1,0 +1,60 @@
+require "application_system_test_case"
+
+class WorkChemicalsDilutionTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:users1)
+    @work = works(:works1)
+
+    visit root_path
+    fill_in 'login_name', with: @user.login_name
+    fill_in 'password', with: 'password'
+    click_button '認証する'
+  end
+
+  test "希釈相互変換(使用量単位がccの場合)" do
+    chemical = chemicals(:chemicals2)
+    chemical.update!(aqueous_flag: true, unit: "cc")
+
+    visit new_work_use_chemical_path(work_id: @work)
+    assert_selector 'h1', text: '作業日報(薬剤)登録'
+
+    quantity_field = find("input[name='chemicals[#{chemical.id}][1][quantity]']", visible: :all)
+    dilution_amount_field = find("input[name='chemicals[#{chemical.id}][1][dilution_amount]']", visible: :all)
+    magnification_field = find("input[name='chemicals[#{chemical.id}][1][magnification]']", visible: :all)
+
+    choose "chemicals_#{chemical.id}_1_#{Dilution::L.id}", visible: :all
+    quantity_field.set("100")
+    quantity_field.send_keys(:tab)
+    dilution_amount_field.set("100")
+    dilution_amount_field.send_keys(:tab)
+    assert_equal "1000.0", magnification_field.value
+
+    choose "chemicals_#{chemical.id}_1_#{Dilution::MAG.id}", visible: :all
+    magnification_field = find("input[name='chemicals[#{chemical.id}][1][magnification]']", visible: :all)
+    dilution_amount_field = find("input[name='chemicals[#{chemical.id}][1][dilution_amount]']", visible: :all)
+    magnification_field.set("200")
+    magnification_field.send_keys(:tab)
+    assert_equal "20.0", dilution_amount_field.value
+  end
+
+  test "希釈相互変換(使用量単位が本など個数単位の場合はbase_quantityで実量換算される)" do
+    chemical = chemicals(:chemicals2)
+    chemical.update!(aqueous_flag: true, unit: "本", base_quantity: 500)
+
+    visit new_work_use_chemical_path(work_id: @work)
+    assert_selector 'h1', text: '作業日報(薬剤)登録'
+
+    quantity_field = find("input[name='chemicals[#{chemical.id}][1][quantity]']", visible: :all)
+    dilution_amount_field = find("input[name='chemicals[#{chemical.id}][1][dilution_amount]']", visible: :all)
+    magnification_field = find("input[name='chemicals[#{chemical.id}][1][magnification]']", visible: :all)
+
+    choose "chemicals_#{chemical.id}_1_#{Dilution::MAG.id}", visible: :all
+    quantity_field.set("2")
+    quantity_field.send_keys(:tab)
+    magnification_field.set("200")
+    magnification_field.send_keys(:tab)
+
+    # 2本 x 500ml(base_quantity) = 1000ml を基準に換算されるため 200倍 => 200ℓ
+    assert_equal "200.0", dilution_amount_field.value
+  end
+end


### PR DESCRIPTION
`/works/:id/chemicals/new` の希釈(ℓ/倍)相互変換について調査・修正しました。

## 原因

使用量欄の単位(`chemical.unit`)からそのまま希釈計算のscaleを引いていたため、単位が本/袋/缶など個数単位(scale 0)の薬剤ではゼロ除算になり、ℓ⇔倍率の相互変換が機能していませんでした。cc/g/ℓ/kg単位の薬剤(scale 1000/1)ではたまたま問題なく動いていたため、一部の薬剤でのみ発生していたと考えられます。

## 修正内容

- `Chemical#dilution_scale` / `#dilution_multiplier` / `#dilution_quantity` を追加し、個数単位の場合は `base_quantity`(1個あたりの内容量)を乗算してcc/g相当の実量に変換してから計算するようにした
- `WorkChemical#dilution_amount` を新メソッド経由の計算に変更
- `app/javascript/pages/edit-chemicals.js` の相互変換ロジックも同様にサーバー側と揃えて修正
- あわせて、希釈の選択肢の表示順が「無、ℓ、倍」で入力欄(希釈倍率→希釈水量(ℓ))と逆順でわかりにくかったため、「無、倍、ℓ」に変更
- モデルテスト・システムテスト(実ブラウザでの相互変換確認)を追加

## コミット

- 9d7aa886 使用量単位が本/袋/缶の場合に希釈相互変換が壊れる不具合を修正
- d8ce92b6 希釈選択肢の表示順を入力欄(倍率→水量ℓ)に合わせて変更

ブランチ: `hotfix-1113`
