### PR TITLE
#901 phase.17 清掃・訓練・その他実績を組織スコープ化

### DIFF
--- a/app/controllers/chemical_costs_controller.rb
+++ b/app/controllers/chemical_costs_controller.rb
@@ -59,11 +59,11 @@ class ChemicalCostsController < ApplicationController
   end
 
   def set_chemical_work_type
-    @chemical_work_type = ChemicalWorkType.joins(:chemical_term).where(chemical_terms: { organization_id: current_organization.id }).find(params[:id])
+    @chemical_work_type = ChemicalWorkType.for_organization(current_organization).find(params[:id])
   end
 
   def destroy_chemical_work_type
-    ChemicalWorkType.joins(:chemical_term).where(chemical_terms: { organization_id: current_organization.id }).where(
+    ChemicalWorkType.for_organization(current_organization).where(
       chemical_term_id: chemical_work_type_params[:chemical_term_id],
       work_type_id: chemical_work_type_params[:work_type_id]
     ).destroy_all

--- a/app/controllers/gaps/accidents_controller.rb
+++ b/app/controllers/gaps/accidents_controller.rb
@@ -3,7 +3,7 @@ class Gaps::AccidentsController < GapsController
   helper GmapHelper
 
   def index
-    @accidents = Accident.usual(current_term)
+    @accidents = Accident.usual(current_term, current_organization)
   end
 
   def show
@@ -55,13 +55,13 @@ class Gaps::AccidentsController < GapsController
   private
 
   def set_accident
-    @accident = Accident.joins(:work).where(works: { organization_id: current_organization.id }).find(params[:id])
+    @accident = Accident.for_organization(current_organization).find(params[:id])
     @works = WorkDecorator.decorate_collection(Work.for_organization(current_organization).usual(@accident.work.term).where(worked_at: @accident.work.worked_at))
     @workers = WorkerDecorator.decorate_collection(@accident.work.workers)
   end
 
   def accident_params
-    params.expect(accident:
+    permitted = params.expect(accident:
       [
         :investigator_id,
         :investigated_on,
@@ -76,5 +76,10 @@ class Gaps::AccidentsController < GapsController
         :solving,
         :result
       ])
+    Work.for_organization(current_organization).find(permitted[:work_id]) if permitted[:work_id].present?
+    [permitted[:investigator_id], permitted[:audience_id]].compact_blank.each do |worker_id|
+      Worker.for_organization(current_organization).find(worker_id)
+    end
+    permitted
   end
 end

--- a/app/controllers/gaps/trainings_controller.rb
+++ b/app/controllers/gaps/trainings_controller.rb
@@ -35,7 +35,7 @@ class Gaps::TrainingsController < GapsController
   end
 
   def traning_params
-    params.expect(training:
+    permitted = params.expect(training:
       [
         :schedule_id,
         :worker_id,
@@ -46,6 +46,8 @@ class Gaps::TrainingsController < GapsController
         :remarks,
         { training_type_ids: [] }
       ])
-      .merge(work_id: params[:id])
+    Worker.for_organization(current_organization).find(permitted[:worker_id]) if permitted[:worker_id].present?
+    Schedule.for_organization(current_organization).find(permitted[:schedule_id]) if permitted[:schedule_id].present?
+    permitted.merge(work_id: params[:id])
   end
 end

--- a/app/models/accident.rb
+++ b/app/models/accident.rb
@@ -46,10 +46,11 @@ class Accident < ApplicationRecord
   def workers_belong_to_work_organization
     return if work.blank?
 
-    errors.add(:investigator_id, "は作業と同じ組織の作業者を指定してください。") if
-      investigator&.organization_id != work.organization_id
-    return if audience&.organization_id == work.organization_id
-
-    errors.add(:audience_id, "は作業と同じ組織の作業者を指定してください。")
+    if investigator.present? && investigator.organization_id != work.organization_id
+      errors.add(:investigator_id, "は作業と同じ組織の作業者を指定してください。")
+    end
+    if audience.present? && audience.organization_id != work.organization_id
+      errors.add(:audience_id, "は作業と同じ組織の作業者を指定してください。")
+    end
   end
 end

--- a/app/models/accident.rb
+++ b/app/models/accident.rb
@@ -27,11 +27,29 @@ class Accident < ApplicationRecord
   belongs_to :investigator, class_name: "Worker"
   belongs_to :audience, class_name: "Worker"
 
-  scope :usual, lambda { |term|
-    joins(:work).where(works: { term: term }).order("works.worked_at, works.start_at, accidents.id")
+  scope :for_organization, lambda { |organization|
+    joins(:work).merge(Work.for_organization(organization))
   }
+  scope :usual, lambda { |term, organization|
+    for_organization(organization).where(works: { term: term })
+      .order("works.worked_at, works.start_at, accidents.id")
+  }
+
+  validate :workers_belong_to_work_organization
 
   def accident_type_name
     I18n.t("activerecord.enums.accident.accident_types.#{accident_type_id}")
+  end
+
+  private
+
+  def workers_belong_to_work_organization
+    return if work.blank?
+
+    errors.add(:investigator_id, "は作業と同じ組織の作業者を指定してください。") if
+      investigator&.organization_id != work.organization_id
+    return if audience&.organization_id == work.organization_id
+
+    errors.add(:audience_id, "は作業と同じ組織の作業者を指定してください。")
   end
 end

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -25,6 +25,10 @@ class Adjustment < ApplicationRecord
   belongs_to :drying
   belongs_to :home, -> { with_deleted }
 
+  scope :for_organization, lambda { |organization|
+    joins(:drying).merge(Drying.for_organization(organization))
+  }
+
   def rice_weight(system)
     ((rice_bag || 0) * Drying::KG_PER_BAG_RICE) + (system.half_sum_flag ? (half_weight || 0) : 0)
   end

--- a/app/models/broccoli_harvest.rb
+++ b/app/models/broccoli_harvest.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: broccoli_harvests(ブロッコリー収穫)
+#
+#  id(ブロッコリー収穫)               :integer          not null, primary key
+#  inspection(検査後数量)             :decimal(3, )     default(0), not null
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
+#  broccoli_rank_id(ブロッコリー等級) :integer          not null
+#  broccoli_size_id(ブロッコリー階級) :integer          not null
+#  work_broccoli_id(ブロッコリー作業) :integer          not null
+#
+class BroccoliHarvest < ApplicationRecord
+  belongs_to :work_broccoli
+
+  scope :for_organization, lambda { |organization|
+    joins(work_broccoli: :work).merge(Work.for_organization(organization))
+  }
+end

--- a/app/models/chemical_work_type.rb
+++ b/app/models/chemical_work_type.rb
@@ -20,6 +20,9 @@ class ChemicalWorkType < ApplicationRecord
   delegate :chemical, to: :chemical_term
   after_save :save_for_zero
 
+  scope :for_organization, lambda { |organization|
+    joins(:chemical_term).merge(ChemicalTerm.for_organization(organization))
+  }
   scope :by_chemical_terms, ->(chemical_terms) { where(chemical_term_id: chemical_terms.pluck(:id)).includes(:work_type, :chemical_term) }
   scope :by_chemical_term,  ->(chemical_term) { where(chemical_term_id: chemical_term).includes(:work_type, :chemical_term) }
   scope :usable, ->(chemical_term) { where(chemical_term_id: chemical_term).where("quantity > 0") }

--- a/app/models/cleaning.rb
+++ b/app/models/cleaning.rb
@@ -18,6 +18,10 @@ class Cleaning < ApplicationRecord
   has_many :institutions, through: :cleaning_institutions
   has_many :cleaning_targets, through: :cleaning_cleaning_targets
 
+  scope :for_organization, lambda { |organization|
+    joins(:work).merge(Work.for_organization(organization))
+  }
+
   def cleaning_target_names
     cleaning_targets.pluck(:name)
   end

--- a/app/models/cleaning_cleaning_target.rb
+++ b/app/models/cleaning_cleaning_target.rb
@@ -15,4 +15,8 @@
 class CleaningCleaningTarget < ApplicationRecord
   belongs_to :cleaning
   belongs_to :cleaning_target
+
+  scope :for_organization, lambda { |organization|
+    joins(cleaning: :work).merge(Work.for_organization(organization))
+  }
 end

--- a/app/models/cleaning_institution.rb
+++ b/app/models/cleaning_institution.rb
@@ -15,4 +15,8 @@
 class CleaningInstitution < ApplicationRecord
   belongs_to :cleaning
   belongs_to :institution
+
+  scope :for_organization, lambda { |organization|
+    joins(cleaning: :work).merge(Work.for_organization(organization))
+  }
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -87,7 +87,8 @@ class Schedule < ApplicationRecord
   }
 
   scope :for_training, lambda { |work|
-    where(worked_at: work.worked_at..)
+    for_organization(work.organization_id)
+      .where(worked_at: work.worked_at..)
       .where("work_flag = FALSE")
       .includes(:work_kind, :schedule_workers)
       .order(worked_at: :ASC, id: :ASC)

--- a/app/models/training.rb
+++ b/app/models/training.rb
@@ -22,11 +22,32 @@ class Training < ApplicationRecord
   belongs_to :teacher, class_name: "Worker", foreign_key: 'worker_id'
   belongs_to :study, class_name: "Schedule", foreign_key: 'schedule_id'
 
+  scope :for_organization, lambda { |organization|
+    joins(:work).merge(Work.for_organization(organization))
+  }
+
+  validate :teacher_belongs_to_work_organization
+  validate :study_belongs_to_work_organization
+
   def studied_on
     study&.worked_at
   end
 
   def studied?
     !worker_id.nil?
+  end
+
+  private
+
+  def teacher_belongs_to_work_organization
+    return if work.blank? || teacher.blank? || teacher.organization_id == work.organization_id
+
+    errors.add(:worker_id, "は作業と同じ組織の作業者を指定してください。")
+  end
+
+  def study_belongs_to_work_organization
+    return if work.blank? || study.blank? || study.organization_id == work.organization_id
+
+    errors.add(:schedule_id, "は作業と同じ組織の予定を指定してください。")
   end
 end

--- a/app/models/training_training_type.rb
+++ b/app/models/training_training_type.rb
@@ -15,4 +15,8 @@
 class TrainingTrainingType < ApplicationRecord
   belongs_to :training_type
   belongs_to :training
+
+  scope :for_organization, lambda { |organization|
+    joins(training: :work).merge(Work.for_organization(organization))
+  }
 end

--- a/app/models/whole_crop_land.rb
+++ b/app/models/whole_crop_land.rb
@@ -23,6 +23,10 @@ class WholeCropLand < ApplicationRecord
 
   has_many :wcs_rolls, -> { order("whole_crop_rolls.display_order") }, class_name: "WholeCropRoll", dependent: :destroy
 
+  scope :for_organization, lambda { |organization|
+    joins(work_whole_crop: :work).merge(Work.for_organization(organization))
+  }
+
   scope :for_sales, lambda { |term|
     joins(work_whole_crop: :work).where(works: { term: term }).where.not(rolls: 0)
   }

--- a/app/models/whole_crop_roll.rb
+++ b/app/models/whole_crop_roll.rb
@@ -14,13 +14,16 @@ class WholeCropRoll < ApplicationRecord
   MAX_ROLLS = 5
 
   scope :valid, -> { where("weight > ?", 0) }
+  scope :for_organization, lambda { |organization|
+    joins(wcs_land: { work_whole_crop: :work }).merge(Work.for_organization(organization))
+  }
 
   belongs_to :wcs_land, class_name: "WholeCropLand", foreign_key: "whole_crop_land_id"
 
   def self.regist(wcs_land, params)
     params.each do |param|
       if param[:id].present?
-        WholeCropRoll.find(param[:id]).update(wcs_roll_param(wcs_land, param))
+        wcs_land.wcs_rolls.find(param[:id]).update(wcs_roll_param(wcs_land, param))
       else
         WholeCropRoll.create(wcs_roll_param(wcs_land, param))
       end

--- a/app/models/work_whole_crop.rb
+++ b/app/models/work_whole_crop.rb
@@ -34,9 +34,9 @@ class WorkWholeCrop < ApplicationRecord
   def self.regist(work, params)
     work_whole_crop = work.whole_crop
     if work_whole_crop
-      work_whole_crop.update(whole_crop_params(params))
+      work_whole_crop.update(whole_crop_params(params).merge(work_id: work.id))
     else
-      work_whole_crop = WorkWholeCrop.create(whole_crop_params(params))
+      work_whole_crop = WorkWholeCrop.create(whole_crop_params(params).merge(work_id: work.id))
     end
     WholeCropLand.regist(work_whole_crop, params.require(:wcs_lands))
   end

--- a/app/views/gaps/accidents/_form.html.erb
+++ b/app/views/gaps/accidents/_form.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-md-3">
       <%= f.label :investigator_id, class: "col-form-label-lg form-label" %>
-      <%= f.select :investigator_id, options_from_collection_for_select(Worker.usual.where(position_id: :director) , :id, :name, f.object.investigator_id), {}, {class: "form-select"} %>
+      <%= f.select :investigator_id, options_from_collection_for_select(Worker.for_organization(current_organization).usual.where(position_id: :director) , :id, :name, f.object.investigator_id), {}, {class: "form-select"} %>
     </div>
     <div class="col-md-3">
       <%= f.label :investigated_on, class: "col-form-label-lg form-label" %>

--- a/test/controllers/cleaning_training_result_organization_scope_test.rb
+++ b/test/controllers/cleaning_training_result_organization_scope_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+class CleaningTrainingResultOrganizationScopeControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @other_organization = organizations(:org2)
+    @other_work = works(:work_other_org)
+    @other_worker = workers(:worker_other_org)
+    login_as(users(:users1))
+  end
+
+  test "ヒヤリハット一覧に他組織の記録を含めない" do
+    Accident.create!(
+      work: @other_work, investigator: @other_worker, audience: @other_worker,
+      accident_type_id: :rule, investigated_on: Date.new(2015, 5, 1),
+      content: "別組織ヒヤリハット"
+    )
+
+    get gaps_accidents_path
+
+    assert_response :success
+    assert_not_includes response.body, "別組織ヒヤリハット"
+  end
+
+  test "ヒヤリハットに他組織の作業と作業者を登録できない" do
+    attributes = {
+      work_id: @other_work.id, investigator_id: @other_worker.id, audience_id: @other_worker.id,
+      accident_type_id: :rule, investigated_on: Date.new(2015, 5, 1)
+    }
+
+    assert_no_difference("Accident.count") do
+      post gaps_accidents_path, params: { accident: attributes }
+    end
+    assert_response :not_found
+  end
+
+  test "研修に他組織の講師と予定を登録できない" do
+    other_schedule = Schedule.create!(
+      organization: @other_organization, term: 2015, worked_at: Date.new(2015, 5, 1),
+      work_kind: work_kinds(:work_kinds2),
+      name: "別組織研修", work_flag: false, created_by: @other_worker.id
+    )
+    attributes = { worker_id: @other_worker.id, schedule_id: other_schedule.id, document: "越境" }
+
+    assert_no_difference("Training.count") do
+      put gaps_training_path(works(:work_study_create)), params: { training: attributes }
+    end
+    assert_response :not_found
+  end
+
+  test "WCS登録でパラメータの他組織作業へ付け替えない" do
+    work = works(:work_wcs)
+    attributes = {
+      work_id: @other_work.id,
+      wcs_lands: [{
+        work_land_id: work_lands(:work_land_wcs1).id,
+        display_order: 1,
+        rolls: 1,
+        wcs_rolls: [{ display_order: 1, weight: 100 }]
+      }]
+    }
+
+    assert_difference("WorkWholeCrop.where(work_id: work.id).count") do
+      assert_no_difference("WorkWholeCrop.where(work_id: @other_work.id).count") do
+        post work_whole_crops_path(work_id: work), params: { whole_crop: attributes }
+      end
+    end
+    assert_redirected_to work_path(id: work)
+  end
+
+  test "WCSロール更新で他組織のロールを指定できない" do
+    other_whole_crop = WorkWholeCrop.create!(work: @other_work)
+    other_work_land = WorkLand.create!(
+      work: @other_work, land: lands(:land_other_org), display_order: 1
+    )
+    other_land = WholeCropLand.create!(
+      work_whole_crop: other_whole_crop, work_land: other_work_land, display_order: 1
+    )
+    other_roll = WholeCropRoll.create!(wcs_land: other_land, display_order: 1, weight: 100)
+    own_land = whole_crop_lands(:wcs_land1)
+    attributes = {
+      work_id: works(:work_wcs2).id,
+      wcs_lands: [{
+        id: own_land.id,
+        work_land_id: own_land.work_land_id,
+        display_order: own_land.display_order,
+        rolls: own_land.rolls,
+        wcs_rolls: [{ id: other_roll.id, display_order: 1, weight: 999 }]
+      }]
+    }
+
+    post work_whole_crops_path(work_id: works(:work_wcs2)), params: { whole_crop: attributes }
+
+    assert_response :not_found
+    assert_equal 100, other_roll.reload.weight
+    assert_equal other_land.id, other_roll.whole_crop_land_id
+  end
+end

--- a/test/models/cleaning_training_result_organization_scope_test.rb
+++ b/test/models/cleaning_training_result_organization_scope_test.rb
@@ -1,0 +1,134 @@
+require "test_helper"
+
+class CleaningTrainingResultOrganizationScopeTest < ActiveSupport::TestCase
+  setup do
+    @organization = organizations(:org)
+    @other_organization = organizations(:org2)
+    @other_work = works(:work_other_org)
+    @other_worker = workers(:worker_other_org)
+    @other_home = homes(:home_other_org)
+    @other_land = lands(:land_other_org)
+
+    create_cleaning_records
+    create_training_records
+    create_chemical_work_type
+    create_adjustment
+    create_broccoli_harvest
+    create_whole_crop_records
+  end
+
+  test "親レコードの組織で清掃・訓練・その他実績を絞り込む" do
+    [
+      @other_cleaning,
+      @other_cleaning_institution,
+      @other_cleaning_target,
+      @other_training,
+      @other_training_type,
+      @other_accident,
+      @other_chemical_work_type,
+      @other_adjustment,
+      @other_broccoli_harvest,
+      @other_whole_crop_land,
+      @other_whole_crop_roll
+    ].each { |record| assert_scoped(record) }
+  end
+
+  test "研修には作業と同じ組織の講師と予定だけを指定できる" do
+    training = Training.new(
+      work: works(:work_study_create), teacher: @other_worker, study: @other_schedule
+    )
+
+    assert_not training.valid?
+    assert training.errors.added?(:worker_id, "は作業と同じ組織の作業者を指定してください。")
+    assert training.errors.added?(:schedule_id, "は作業と同じ組織の予定を指定してください。")
+  end
+
+  test "ヒヤリハットには作業と同じ組織の調査責任者と対象者だけを指定できる" do
+    accident = Accident.new(
+      work: works(:works1), investigator: @other_worker, audience: @other_worker,
+      accident_type_id: :rule, investigated_on: Date.new(2015, 5, 1)
+    )
+
+    assert_not accident.valid?
+    assert accident.errors.added?(:investigator_id, "は作業と同じ組織の作業者を指定してください。")
+    assert accident.errors.added?(:audience_id, "は作業と同じ組織の作業者を指定してください。")
+  end
+
+  test "研修候補予定に他組織の予定を含めない" do
+    assert_not_includes Schedule.for_training(works(:work_study_create)), @other_schedule
+  end
+
+  private
+
+  def create_cleaning_records
+    @other_cleaning = Cleaning.create!(work: @other_work)
+    @other_cleaning_institution = CleaningInstitution.create!(
+      cleaning: @other_cleaning, institution: institutions(:jimusho)
+    )
+    @other_cleaning_target = CleaningCleaningTarget.create!(
+      cleaning: @other_cleaning, cleaning_target: cleaning_targets(:cleaning_target1)
+    )
+  end
+
+  def create_training_records
+    @other_schedule = Schedule.create!(
+      organization: @other_organization, term: 2015, worked_at: Date.new(2015, 5, 1),
+      work_kind: work_kinds(:work_kinds2),
+      name: "別組織研修", work_flag: false, created_by: @other_worker.id
+    )
+    @other_training = Training.create!(
+      work: @other_work, teacher: @other_worker, study: @other_schedule
+    )
+    @other_training_type = TrainingTrainingType.create!(
+      training: @other_training, training_type: training_types(:training_type1)
+    )
+    @other_accident = Accident.create!(
+      work: @other_work, investigator: @other_worker, audience: @other_worker,
+      accident_type_id: :rule, investigated_on: Date.new(2015, 5, 1)
+    )
+  end
+
+  def create_chemical_work_type
+    chemical = Chemical.create!(
+      organization: @other_organization, chemical_type: chemical_types(:chemical_types1),
+      name: "別組織薬剤", phonetic: "べつそしきやくざい", display_order: 1
+    )
+    chemical_term = ChemicalTerm.create!(
+      organization: @other_organization, chemical: chemical, term: 2015
+    )
+    @other_chemical_work_type = ChemicalWorkType.create!(
+      chemical_term: chemical_term, work_type: work_types(:work_types1), quantity: 1
+    )
+  end
+
+  def create_adjustment
+    drying = Drying.create!(
+      home: @other_home, work_type: work_types(:work_types1), term: 2015,
+      carried_on: Date.new(2015, 10, 10), drying_type_id: :another
+    )
+    @other_adjustment = Adjustment.create!(drying: drying, home: @other_home)
+  end
+
+  def create_broccoli_harvest
+    broccoli = WorkBroccoli.create!(work: @other_work, shipped_on: Date.new(2015, 5, 1))
+    @other_broccoli_harvest = BroccoliHarvest.create!(
+      work_broccoli: broccoli, broccoli_rank_id: 1, broccoli_size_id: 1
+    )
+  end
+
+  def create_whole_crop_records
+    whole_crop = WorkWholeCrop.create!(work: @other_work)
+    work_land = WorkLand.create!(work: @other_work, land: @other_land, display_order: 1)
+    @other_whole_crop_land = WholeCropLand.create!(
+      work_whole_crop: whole_crop, work_land: work_land, display_order: 1
+    )
+    @other_whole_crop_roll = WholeCropRoll.create!(
+      wcs_land: @other_whole_crop_land, display_order: 1, weight: 100
+    )
+  end
+
+  def assert_scoped(record)
+    assert record.class.for_organization(@other_organization).exists?(record.id), record.class.name
+    assert_not record.class.for_organization(@organization).exists?(record.id), record.class.name
+  end
+end

--- a/test/models/cleaning_training_result_organization_scope_test.rb
+++ b/test/models/cleaning_training_result_organization_scope_test.rb
@@ -54,6 +54,15 @@ class CleaningTrainingResultOrganizationScopeTest < ActiveSupport::TestCase
     assert accident.errors.added?(:audience_id, "は作業と同じ組織の作業者を指定してください。")
   end
 
+  test "ヒヤリハットの作業者が未設定でも組織越境エラーを追加しない" do
+    accident = Accident.new(work: works(:works1))
+
+    accident.valid?
+
+    assert_not accident.errors.added?(:investigator_id, "は作業と同じ組織の作業者を指定してください。")
+    assert_not accident.errors.added?(:audience_id, "は作業と同じ組織の作業者を指定してください。")
+  end
+
   test "研修候補予定に他組織の予定を含めない" do
     assert_not_includes Schedule.for_training(works(:work_study_create)), @other_schedule
   end


### PR DESCRIPTION
## phase.17 完了メモ: 清掃・訓練・その他実績の組織スコープ対応

Phase.17 の計画どおり、DB migration なしで、清掃・訓練・その他実績を既存の親レコード経由で組織スコープ化しました。

### 今回やったこと

1. 清掃・訓練・その他実績モデルに `for_organization` を追加
   - 清掃関連: `Cleaning`, `CleaningInstitution`, `CleaningCleaningTarget`
   - 訓練関連: `Training`, `TrainingTrainingType`
   - その他実績: `Accident`, `Adjustment`, `ChemicalWorkType`
   - WCS関連: `WholeCropLand`, `WholeCropRoll`
   - 削除済みのブロッコリー画面は復活させず、残存する `broccoli_harvests` 用の最小モデルと組織スコープを追加

2. ヒヤリハットの表示・登録・更新経路を組織スコープ化
   - 一覧と個別取得を `current_organization` で制限
   - 調査責任者候補を現在組織の作業者に限定
   - `work_id`, `investigator_id`, `audience_id` の直接指定でも他組織データを登録・更新できないようにしました。

3. 研修関連の越境更新を防止
   - 研修候補予定を対象作業と同じ組織に限定
   - 講師と予定が対象作業と同じ組織に属することを検証
   - パラメータで他組織の `worker_id` / `schedule_id` を指定できないようにしました。

4. WCS関連の越境更新を防止
   - リクエスト内の `work_id` ではなく、組織スコープ済みの対象作業を使用
   - WCSロール更新を親のWCS土地配下から取得し、他組織のロールIDを直接指定して更新・付け替えできないようにしました。

5. org2 混入防止テストを追加
   - Phase.17 対象モデルが親レコードの組織で正しく絞り込まれること
   - ヒヤリハット一覧に他組織データが混ざらないこと
   - 他組織の作業者・予定・作業・WCSロールを直接指定できないこと
   - 既存1組織での部分更新など、従来挙動が維持されること

### 検証結果

全テスト:

```text
1123 runs, 4698 assertions, 0 failures, 0 errors, 0 skips
```

新規・主要変更12ファイルの RuboCop は offenses なし、`git diff --check` も問題ありません。

### コミット

```text
76e380da #901 phase.17 清掃・訓練・その他実績を組織スコープ化
```