### PR TITLE
#10 phase.5 年度選択をSystem基準に変更

### DIFF
--- a/app/controllers/calendar_work_kinds_controller.rb
+++ b/app/controllers/calendar_work_kinds_controller.rb
@@ -2,7 +2,7 @@ class CalendarWorkKindsController < ApplicationController
   include PermitManager
 
   def index
-    @terms = WorkDecorator.terms
+    @terms = calendar_terms
     @work_kinds = WorkKind.usual.to_a
     @calendar_work_kinds = CalendarWorkKind.usual(current_user).to_a
   end
@@ -13,5 +13,13 @@ class CalendarWorkKindsController < ApplicationController
       CalendarWorkKind.regist(session[:user_id], params)
     end
     redirect_to calendars_path
+  end
+
+  private
+
+  def calendar_terms
+    first_work_year = Work.for_organization(current_organization).minimum(:worked_at)&.year
+    first_year = [first_work_year, current_user.calendar_term].compact.min || Time.zone.now.year
+    (first_year..Time.zone.now.year).map { |year| [year, year] }
   end
 end

--- a/app/controllers/chemicals/stocks_controller.rb
+++ b/app/controllers/chemicals/stocks_controller.rb
@@ -4,7 +4,9 @@ class Chemicals::StocksController < ApplicationController
   before_action :set_chemical_term, only: [:search, :new, :edit, :create, :update]
   before_action :set_stock, only: [:edit, :update, :destroy]
 
-  def index; end
+  def index
+    @terms = WorkDecorator.terms(current_organization)
+  end
 
   def load
     @chemicals = ChemicalTerm.by_type(params[:term], params[:chemical_type_id], current_organization)

--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -20,7 +20,7 @@ class MenuController < ApplicationController
   end
 
   def edit_term
-    @terms = WorkDecorator.terms
+    @terms = WorkDecorator.terms(current_organization)
   end
 
   def update
@@ -39,7 +39,7 @@ class MenuController < ApplicationController
       end
       redirect_to(menu_index_path, notice: '設定を変更しました。')
     else
-      @terms = WorkDecorator.terms
+      @terms = WorkDecorator.terms(current_organization)
       render action: :edit_term
     end
   end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -17,7 +17,7 @@ class WorksController < ApplicationController
   helper GmapHelper
 
   def index
-    @terms = WorkDecorator.terms
+    @terms = WorkDecorator.terms(current_organization)
 
     # term は params 優先。なければ current_term
     @term = params[:term].presence || current_term

--- a/app/decorators/work_decorator.rb
+++ b/app/decorators/work_decorator.rb
@@ -5,15 +5,8 @@ class WorkDecorator < Draper::Decorator
   decorates_association :creator
   decorates_association :printer
 
-  def self.terms
-    terms = []
-    term = Work.minimum(:term)
-    term ||= Time.zone.now.year
-    while term <= Time.zone.now.year
-      terms << [term, term]
-      term += 1
-    end
-    terms
+  def self.terms(organization)
+    System.where(organization_id: organization.id).order(:term).pluck(:term_name, :term)
   end
 
   def worked_at

--- a/app/views/chemicals/stocks/index.html.erb
+++ b/app/views/chemicals/stocks/index.html.erb
@@ -3,7 +3,7 @@
   <div class="col-md-3">
     <div class="input-group">
       <label for="term" class="h5 form-label">年度</label>
-      <%= select_tag(:term, options_for_select(WorkDecorator.terms, selected: current_term), {class: "form-select"}) %>
+      <%= select_tag(:term, options_for_select(@terms, selected: current_term), {class: "form-select"}) %>
     </div>
   </div>
   <div class="col-md-3">

--- a/test/controllers/calendar_work_kinds_controller_test.rb
+++ b/test/controllers/calendar_work_kinds_controller_test.rb
@@ -10,8 +10,13 @@ class CalendarWorkKindsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "カレンダー制御" do
+    systems(:s2014).update!(term_name: "第14期")
+
     get calendar_work_kinds_path
+
     assert_response :success
+    assert_select "select#calendar_term option[value='2014']", text: "2014"
+    assert_select "select#calendar_term option", text: "第14期", count: 0
   end
 
   test "カレンダー制御(管理者以外)" do

--- a/test/controllers/chemicals/stocks_controller_test.rb
+++ b/test/controllers/chemicals/stocks_controller_test.rb
@@ -8,8 +8,13 @@ class Chemicals::StocksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "農薬在庫一覧" do
+    systems(:s2015).update!(term_name: "第15期")
+
     get chemicals_stocks_path
+
     assert_response :success
+    assert_select "select#term option[value='2015']", text: "第15期"
+    assert_select "select#term option", text: systems(:s2015_org2).term_name, count: 0
   end
 
   test "農薬在庫一覧(管理者以外)" do

--- a/test/controllers/menu_controller_test.rb
+++ b/test/controllers/menu_controller_test.rb
@@ -14,8 +14,13 @@ class MenuControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "対象年度変更画面表示" do
+    systems(:s2015).update!(term_name: "第15期")
+
     get edit_term_menu_path(@system.id)
+
     assert_response :success
+    assert_select "select#system_term option[value='2015']", text: "第15期"
+    assert_select "select#system_term option", text: systems(:s2015_org2).term_name, count: 0
   end
 
   test "対象年度変更(実行:新規)" do

--- a/test/controllers/works_controller_test.rb
+++ b/test/controllers/works_controller_test.rb
@@ -12,8 +12,13 @@ class WorksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "作業一覧" do
+    systems(:s2015).update!(term_name: "第15期")
+
     get works_path
+
     assert_response :success
+    assert_select "select#term option[value='2015']", text: "第15期"
+    assert_select "select#term option", text: systems(:s2015_org2).term_name, count: 0
   end
 
   test "作業登録(表示)" do

--- a/test/decorators/work_decorator_test.rb
+++ b/test/decorators/work_decorator_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class WorkDecoratorTest < ActiveSupport::TestCase
+  test "組織の年度名と年度を年度順で返す" do
+    systems(:s2014).update!(term_name: "第14期")
+    systems(:s2015).update!(term_name: "第15期")
+    systems(:s2015_org2).update!(term_name: "別組織期")
+
+    terms = WorkDecorator.terms(organizations(:org))
+
+    assert_equal ["第14期", 2014], terms.first
+    assert_includes terms, ["第15期", 2015]
+    assert_not_includes terms, ["別組織期", 2015]
+  end
+end


### PR DESCRIPTION
## Phase.5 完了

年度選択肢を西暦年の自動生成から、組織ごとの `System#term_name` / `term` を参照する形式へ変更しました。あわせて、カレンダーの暦年選択を年度（期）の選択ロジックから分離しました。

- `WorkDecorator.terms(organization)` を追加し、組織別の `System` を年度順に `[term_name, term]` で返すよう変更
- 作業一覧・対象年度変更・農薬在庫一覧の年度選択に適用
- 農薬在庫一覧の年度選択肢を controller で準備する形に統一
- `calendar_work_kinds_controller` は、組織内の作業日と現在選択中の暦年を基準に西暦年候補を生成する専用ロジックへ分離
- 任意の年度名の表示、他組織の年度除外、カレンダーで年度名を混同しないことの回帰テストを追加

Commit: `497c9945` (`#10 phase.5 年度選択をSystem基準に変更`)

確認結果:
- `bin/rails test test/decorators/work_decorator_test.rb test/controllers/works_controller_test.rb test/controllers/menu_controller_test.rb test/controllers/calendar_work_kinds_controller_test.rb test/controllers/chemicals/stocks_controller_test.rb`
- 33 runs / 174 assertions / 0 failures / 0 errors
- `bin/rails test`: 成功
- 追加・変更したテスト等6ファイルの RuboCop: 違反なし
- `git diff --check`: 問題なし