### PR TITLE
#1123 軽トラック利用一覧に機械の稼働期間チェックを追加

### DIFF
--- a/app/controllers/works/trucks_controller.rb
+++ b/app/controllers/works/trucks_controller.rb
@@ -139,7 +139,11 @@ class Works::TrucksController < ApplicationController
   end
 
   def truck_has_result?(truck)
-    @machine_result_hours.keys.any? { |(machine_id, _work_result_id)| machine_id == truck.id }
+    machine_ids_with_results.include?(truck.id)
+  end
+
+  def machine_ids_with_results
+    @machine_ids_with_results ||= @machine_result_hours.keys.to_set(&:first)
   end
 
   def machine_active_by_work_id_and_machine_id

--- a/app/controllers/works/trucks_controller.rb
+++ b/app/controllers/works/trucks_controller.rb
@@ -31,10 +31,12 @@ class Works::TrucksController < ApplicationController
     @selected_month = selected_month
     @sections = truck_sections
     @selected_section = selected_section
-    @trucks = Machine.trucks(current_organization, section: @selected_section)
+    @all_trucks = Machine.trucks(current_organization, section: @selected_section)
     @machine_result_hours = machine_result_hours
     @work_result_by_work_id_and_machine_id = work_result_by_work_id_and_machine_id
     @works = WorkDecorator.decorate_collection(truck_works)
+    @trucks = display_trucks
+    @machine_active_by_work_id_and_machine_id = machine_active_by_work_id_and_machine_id
   end
 
   def truck_work_kinds
@@ -98,7 +100,7 @@ class Works::TrucksController < ApplicationController
     @work_result_by_work_id_and_machine_id ||= work_result_groups.each_with_object({}) do |group, hash|
       (work_id, home_id), results = group
 
-      @trucks.select { |truck| truck.home_id == home_id }.each do |truck|
+      @all_trucks.select { |truck| truck.home_id == home_id }.each do |truck|
         hash[[work_id, truck.id]] = canonical_work_result(truck, results)
       end
     end
@@ -122,14 +124,46 @@ class Works::TrucksController < ApplicationController
 
   def machine_result_hours
     @machine_result_hours ||= MachineResult
-      .where(work_result_id: truck_work_results.map(&:id), machine_id: @trucks.map(&:id))
+      .where(work_result_id: truck_work_results.map(&:id), machine_id: @all_trucks.map(&:id))
       .index_by { |result| [result.machine_id, result.work_result_id] }
+  end
+
+  def display_trucks
+    @all_trucks.select { |truck| truck_active_in_month?(truck) || truck_has_result?(truck) }
+  end
+
+  def truck_active_in_month?(truck)
+    return false unless @selected_month
+
+    truck.validity_start_at <= @selected_month.end_of_month && truck.validity_end_at >= @selected_month
+  end
+
+  def truck_has_result?(truck)
+    @machine_result_hours.keys.any? { |(machine_id, _work_result_id)| machine_id == truck.id }
+  end
+
+  def machine_active_by_work_id_and_machine_id
+    @works.each_with_object({}) do |work, hash|
+      @trucks.each do |truck|
+        work_result = @work_result_by_work_id_and_machine_id[[work.id, truck.id]]
+        next unless work_result
+
+        machine_result = @machine_result_hours[[truck.id, work_result.id]]
+        hash[[work.id, truck.id]] = machine_active?(truck, work.model.worked_at, machine_result)
+      end
+    end
+  end
+
+  def machine_active?(truck, worked_at, machine_result)
+    return true if machine_result.present?
+
+    worked_at.between?(truck.validity_start_at, truck.validity_end_at)
   end
 
   def save_machine_hours
     Work::TrucksRegistrar.new(
       machine_hours: machine_hour_params,
-      trucks: @trucks,
+      trucks: @all_trucks,
       work_results: @work_result_by_work_id_and_machine_id.values.uniq
     ).call
   end

--- a/app/services/work/trucks_registrar.rb
+++ b/app/services/work/trucks_registrar.rb
@@ -35,10 +35,24 @@ class Work::TrucksRegistrar
 
   def editable_work_result(work_result_id, truck)
     work_result = work_results.find { |result| result.id == work_result_id }
-    return if work_result&.work&.fixed_at.present?
-    return if work_result&.worker&.home_id != truck.home_id
+    return unless work_result
+    return unless registrable?(work_result, truck)
 
     work_result
+  end
+
+  def registrable?(work_result, truck)
+    return false if work_result.work.fixed_at.present?
+    return false if work_result.worker.home_id != truck.home_id
+
+    machine_active?(truck, work_result)
+  end
+
+  def machine_active?(truck, work_result)
+    worked_at = work_result.work.worked_at
+    return true if worked_at.between?(truck.validity_start_at, truck.validity_end_at)
+
+    MachineResult.exists?(machine_id: truck.id, work_result_id: work_result.id)
   end
 
   def save_machine_result(machine_id, work_result_id, hours_value)

--- a/app/views/works/trucks/index.html.erb
+++ b/app/views/works/trucks/index.html.erb
@@ -44,7 +44,7 @@
           <% work_result = @work_result_by_work_id_and_machine_id[[work.id, truck.id]] %>
           <% machine_result = @machine_result_hours[[truck.id, work_result.id]] if work_result %>
           <td>
-            <% if work_result %>
+            <% if work_result && @machine_active_by_work_id_and_machine_id[[work.id, truck.id]] %>
               <%= number_field_tag "machine_hours[#{truck.id}][#{work_result.id}]", machine_result&.hours || 0, {min: 0, max: 9.5, step: 0.5, required: true, readonly: work.fixed_at.present?, class: "form-control form-control-sm", style: "width: 80px;"} %>
             <% end %>
           </td>

--- a/test/controllers/works/trucks_controller_test.rb
+++ b/test/controllers/works/trucks_controller_test.rb
@@ -100,6 +100,51 @@ class Works::TrucksControllerTest < ActionDispatch::IntegrationTest
     assert_select "th", text: homes(:home6).name
   end
 
+  test "稼働期間が選択月と重ならないトラックは列を表示しない" do
+    other_home_truck = create_truck(
+      homes(:home2),
+      validity_start_at: Date.new(2015, 3, 1),
+      validity_end_at: Date.new(2015, 3, 31)
+    )
+
+    get works_trucks_path, params: { month: "2015-02-01" }
+
+    assert_response :success
+    assert_select "th", text: other_home_truck.owner.name, count: 0
+  end
+
+  test "稼働期間が選択月の一部と重なるトラックは列を表示する" do
+    other_home_truck = create_truck(
+      homes(:home2),
+      validity_start_at: Date.new(2015, 2, 20),
+      validity_end_at: Date.new(2015, 3, 10)
+    )
+
+    get works_trucks_path, params: { month: "2015-02-01" }
+
+    assert_response :success
+    assert_select "th", text: other_home_truck.owner.name
+  end
+
+  test "稼働期間外の作業日には入力欄を表示しない" do
+    active_work = create_work(Date.new(2015, 2, 5), work_kinds(:work_kind_shirokaki))
+    inactive_work = create_work(Date.new(2015, 2, 15), work_kinds(:work_kind_shirokaki))
+    health = Health.create!(code: "T", name: "良好", display_order: 999, well_flag: true)
+    active_result = WorkResult.create!(
+      work: active_work, worker: workers(:worker1), health: health, hours: 1.0, display_order: 1
+    )
+    inactive_result = WorkResult.create!(
+      work: inactive_work, worker: workers(:worker1), health: health, hours: 1.0, display_order: 1
+    )
+    truck = create_truck(homes(:home1), validity_start_at: Date.new(2015, 2, 1), validity_end_at: Date.new(2015, 2, 10))
+
+    get works_trucks_path, params: { work_kind_id: work_kinds(:work_kind_shirokaki).id, month: "2015-02-01" }
+
+    assert_response :success
+    assert_select "input[name='machine_hours[#{truck.id}][#{active_result.id}]']", 1
+    assert_select "input[name='machine_hours[#{truck.id}][#{inactive_result.id}]']", 0
+  end
+
   private
 
   def create_work(worked_at, work_kind)
@@ -117,12 +162,12 @@ class Works::TrucksControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  def create_truck(home)
+  def create_truck(home, validity_start_at: Date.new(2015, 1, 1), validity_end_at: Date.new(2099, 12, 31))
     Machine.create!(
       name: "",
       display_order: 1,
-      validity_start_at: Date.new(2015, 1, 1),
-      validity_end_at: Date.new(2099, 12, 31),
+      validity_start_at: validity_start_at,
+      validity_end_at: validity_end_at,
       machine_type_id: @truck_type.id,
       home_id: home.id,
       diesel_flag: false

--- a/test/controllers/works/trucks_registration_controller_test.rb
+++ b/test/controllers/works/trucks_registration_controller_test.rb
@@ -107,6 +107,53 @@ class Works::TrucksRegistrationControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1.5, machine_result.reload.hours
   end
 
+  test "稼働期間外の作業日への machine_result 追加は無視する" do
+    out_of_period_truck = create_truck(
+      homes(:home1),
+      validity_start_at: Date.new(2015, 3, 1),
+      validity_end_at: Date.new(2015, 3, 31)
+    )
+    work = create_work(Date.new(2015, 2, 5), work_kinds(:work_kind_shirokaki))
+    work_result = create_work_result(work, workers(:worker1))
+
+    assert_no_difference("MachineResult.count") do
+      post works_trucks_path, params: filter_params.merge(
+        machine_hours: { out_of_period_truck.id => { work_result.id => "2.5" } }
+      )
+    end
+
+    assert_redirected_to works_trucks_path(filter_params)
+    assert_nil MachineResult.find_by(machine: out_of_period_truck, work_result: work_result)
+  end
+
+  test "稼働期間外でも既存 machine_result は更新・削除できる" do
+    out_of_period_truck = create_truck(
+      homes(:home1),
+      validity_start_at: Date.new(2015, 3, 1),
+      validity_end_at: Date.new(2015, 3, 31)
+    )
+    work = create_work(Date.new(2015, 2, 5), work_kinds(:work_kind_shirokaki))
+    work_result = create_work_result(work, workers(:worker1))
+    machine_result = MachineResult.create!(machine: out_of_period_truck, work_result: work_result, hours: 1.5)
+
+    assert_no_difference("MachineResult.count") do
+      post works_trucks_path, params: filter_params.merge(
+        machine_hours: { out_of_period_truck.id => { work_result.id => "3.0" } }
+      )
+    end
+
+    assert_redirected_to works_trucks_path(filter_params)
+    assert_equal 3.0, machine_result.reload.hours
+
+    assert_difference("MachineResult.count", -1) do
+      post works_trucks_path, params: filter_params.merge(
+        machine_hours: { out_of_period_truck.id => { work_result.id => "0" } }
+      )
+    end
+
+    assert_nil MachineResult.find_by(id: machine_result.id)
+  end
+
   private
 
   def filter_params
@@ -137,12 +184,12 @@ class Works::TrucksRegistrationControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  def create_truck(home)
+  def create_truck(home, validity_start_at: Date.new(2015, 1, 1), validity_end_at: Date.new(2099, 12, 31))
     Machine.create!(
       name: "",
       display_order: 1,
-      validity_start_at: Date.new(2015, 1, 1),
-      validity_end_at: Date.new(2099, 12, 31),
+      validity_start_at: validity_start_at,
+      validity_end_at: validity_end_at,
       machine_type_id: @truck_type.id,
       home_id: home.id,
       diesel_flag: false


### PR DESCRIPTION
## Summary
- 軽トラック利用一覧(works/trucks)で、機械の稼働期間(`validity_start_at`〜`validity_end_at`)が加味されていなかった問題を修正
- 作業日(worked_at)がトラックの稼働期間外の場合、入力欄を表示せず、登録処理(`Work::TrucksRegistrar`)側でも拒否するようにした
- 既に記録済みの実績がある場合は表示・更新・削除を維持する(Machine.by_workと同じ考え方)

## Test plan
- [x] `bin/rails test test/controllers/works/trucks_controller_test.rb`
- [x] `bin/rails test test/controllers/works/trucks_registration_controller_test.rb`
- [x] `bin/rails test test/controllers/works/trucks_inputs_controller_test.rb`
- [x] `bin/rails test test/controllers/machines/trucks_controller_test.rb`
- [x] `bundle exec rubocop` (対象ファイル)

Closes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)