### PR TITLE
#1119 交通費(自家用車賃借料)を15分単位に対応

### DIFF
--- a/app/assets/stylesheets/pc-common.css
+++ b/app/assets/stylesheets/pc-common.css
@@ -61,6 +61,7 @@ div.d-table.float-head div.d-table-row.fix-head {
 div.float-head-wrapper {
   overflow-y: scroll;
   height: calc(100vh - 400px);
+  padding-right: 12px;
 }
 
 .tr-total1,

--- a/app/decorators/machine_result_decorator.rb
+++ b/app/decorators/machine_result_decorator.rb
@@ -36,7 +36,7 @@ class MachineResultDecorator < Draper::Decorator
   def quantity
     case model.adjust
     when Adjust::HOUR
-      h.number_to_currency(model.quantity, { precision: 1, unit: "" })
+      h.number_to_currency(model.quantity, { precision: 2, unit: "" })
     when Adjust::DAY
       h.number_to_currency(model.quantity, { precision: 0, unit: "" })
     when Adjust::AREA

--- a/app/models/machine_result.rb
+++ b/app/models/machine_result.rb
@@ -8,7 +8,7 @@
 #  fixed_price(確定稼動単価)      :decimal(5, )
 #  fixed_quantity(確定稼動量)     :decimal(6, 2)
 #  fuel_usage(燃料使用量)         :decimal(5, 2)    default(0.0), not null
-#  hours(稼動時間)                :decimal(3, 1)    default(0.0), not null
+#  hours(稼動時間)                :decimal(4, 2)    default(0.0), not null
 #  created_at                     :datetime
 #  updated_at                     :datetime
 #  fixed_adjust_id(確定稼動単位)  :integer

--- a/app/services/work/trucks_registrar.rb
+++ b/app/services/work/trucks_registrar.rb
@@ -1,7 +1,7 @@
 class Work::TrucksRegistrar
   MIN_HOURS = BigDecimal("0")
   MAX_HOURS = BigDecimal("9.5")
-  HOUR_STEP = BigDecimal("0.5")
+  HOUR_STEP = BigDecimal("0.25")
 
   def initialize(machine_hours:, trucks:, work_results:)
     @machine_hours = machine_hours

--- a/app/views/fixes/new.html.erb
+++ b/app/views/fixes/new.html.erb
@@ -31,7 +31,7 @@
         <th class="numeric">工数</th>
         <th class="numeric">単価</th>
         <th class="numeric">日当</th>
-        <th class="numeric">機械使用料</th>
+        <th class="numeric" style="width: 90px;">機械使用料</th>
       </tr>
     </thead>
     <tbody id="tbody_works">
@@ -47,7 +47,7 @@
           <% price = work.work_kind.term_price(current_term) %>
           <td class="numeric"><%=h number_with_delimiter(price, {precision: 0}) %></td>
           <td id="amount_<%= work.id %>" class="numeric"><%=h number_with_delimiter((hours * price).to_i, {precision: 0}) %></td>
-          <td id="machine_<%= work.id %>" class="numeric"><%=h number_with_delimiter(work.sum_machines_amount.to_i, {precision: 0}) %></td>
+          <td id="machine_<%= work.id %>" class="numeric"><%=h work.sum_machines_amount %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/works/_show_machines.html.erb
+++ b/app/views/works/_show_machines.html.erb
@@ -12,7 +12,7 @@
       <% [current_organization.machines_count, @machines.count].max.times do |i| %>
       <tr>
         <td class="machine"><%= @machines[i] ? @machines[i].usual_name : "" %></td>
-        <td class="machine numeric"><%=@machines[i] ? @machines[i].hours(@results.object) : "" %></td>
+        <td class="machine numeric"><%=@machines[i] ? format("%.2f", @machines[i].hours(@results.object)) : "" %></td>
         <td class="machine"><%= @machines[i] ? @machines[i].operators(@work) : "" %></td>
         <td class="machine"><%= @machines[i] ? @machines[i].remarks(@work)&.remarks : "" %></td>
       </tr>

--- a/app/views/works/machines/new.html.erb
+++ b/app/views/works/machines/new.html.erb
@@ -28,7 +28,7 @@
               <td><%= result.worker.name %></td>
                 <% @company_machines.each do |machine| %>
                   <% machine_result = result.machine_results.where(machine_id: machine).first %>
-                  <td><%= number_field_tag "machine_hours[#{machine.id}][#{result.id}]", machine_result ? machine_result.hours : 0, {step:0.5, min: 0, max: 99, class: "form-control", style: "width: 80px;"} %></td>
+                  <td><%= number_field_tag "machine_hours[#{machine.id}][#{result.id}]", format("%.2f", machine_result ? machine_result.hours : 0), {step: 0.25, min: 0, max: 99, class: "form-control", style: "width: 80px;"} %></td>
                 <% end %>
             </tr>
           <% end %>
@@ -58,7 +58,7 @@
                   <% if machines.exists? %>
                   <%   machine = machines.first %>
                   <%   machine_results = result.machine_results.where(machine_id: machine) %>
-                  <td><%= number_field_tag "machine_hours[#{machine.id}][#{result.id}]", machine_results.exists? ? machine_results.first.hours : 0, {step:0.5, min: 0, max: 99, class: "form-control form-control-sm", style: "width: 80px;"} %></td>
+                  <td><%= number_field_tag "machine_hours[#{machine.id}][#{result.id}]", format("%.2f", machine_results.exists? ? machine_results.first.hours : 0), {step: 0.25, min: 0, max: 99, class: "form-control form-control-sm", style: "width: 80px;"} %></td>
                   <% else %>
                   <td>&nbsp;</td>
                   <% end %>
@@ -86,7 +86,7 @@
                 <% @lease_machines.each do |machine| %>
                   <% machine_result = result.machine_results.where(machine_id: machine).first %>
                   <td>
-                    <%= number_field_tag "machine_hours[#{machine.id}][#{result.id}]", machine_result ? machine_result.hours : 0, {step:0.5, min: 0, max: 99, class: "form-control form-control-sm", style: "width: 80px;"} %>
+                    <%= number_field_tag "machine_hours[#{machine.id}][#{result.id}]", format("%.2f", machine_result ? machine_result.hours : 0), {step: 0.25, min: 0, max: 99, class: "form-control form-control-sm", style: "width: 80px;"} %>
                   </td>
                 <% end %>
             </tr>

--- a/app/views/works/trucks/index.html.erb
+++ b/app/views/works/trucks/index.html.erb
@@ -45,7 +45,7 @@
           <% machine_result = @machine_result_hours[[truck.id, work_result.id]] if work_result %>
           <td>
             <% if work_result && @machine_active_by_work_id_and_machine_id[[work.id, truck.id]] %>
-              <%= number_field_tag "machine_hours[#{truck.id}][#{work_result.id}]", machine_result&.hours || 0, {min: 0, max: 9.5, step: 0.5, required: true, readonly: work.fixed_at.present?, class: "form-control form-control-sm", style: "width: 80px;"} %>
+              <%= number_field_tag "machine_hours[#{truck.id}][#{work_result.id}]", format("%.2f", machine_result&.hours || 0), {min: 0, max: 9.5, step: 0.25, required: true, readonly: work.fixed_at.present?, class: "form-control form-control-sm", style: "width: 80px;"} %>
             <% end %>
           </td>
         <% end %>

--- a/db/migrate/20260801010000_change_hours_scale_on_machine_results.rb
+++ b/db/migrate/20260801010000_change_hours_scale_on_machine_results.rb
@@ -1,0 +1,11 @@
+class ChangeHoursScaleOnMachineResults < ActiveRecord::Migration[8.1]
+  def up
+    change_column :machine_results, :hours, :decimal,
+                  precision: 4, scale: 2, default: "0.0", null: false, comment: "稼動時間"
+  end
+
+  def down
+    change_column :machine_results, :hours, :decimal,
+                  precision: 3, scale: 1, default: "0.0", null: false, comment: "稼動時間"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_04_010000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_01_010000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgroonga"
@@ -551,7 +551,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_010000) do
     t.decimal "fixed_price", precision: 5, comment: "確定稼動単価"
     t.decimal "fixed_quantity", precision: 6, scale: 2, comment: "確定稼動量"
     t.decimal "fuel_usage", precision: 5, scale: 2, default: "0.0", null: false, comment: "燃料使用量"
-    t.decimal "hours", precision: 3, scale: 1, default: "0.0", null: false, comment: "稼動時間"
+    t.decimal "hours", precision: 4, scale: 2, default: "0.0", null: false, comment: "稼動時間"
     t.integer "machine_id", comment: "機械"
     t.datetime "updated_at", precision: nil
     t.integer "work_result_id", comment: "作業結果データ"

--- a/test/controllers/fixes_controller_test.rb
+++ b/test/controllers/fixes_controller_test.rb
@@ -28,6 +28,16 @@ class FixesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "新規確定(表示) 機械使用料はカンマ区切りのまま表示され桁落ちしない" do
+    work = works(:work_no_fix1)
+    Work.any_instance.stubs(:sum_machines_amount).returns(BigDecimal("5250"))
+
+    get new_fix_path
+
+    assert_response :success
+    assert_select "#machine_#{work.id}", text: "5,250"
+  end
+
   test "新規確定(実行)" do
     fixed_at = '2015-03-31'
     assert_enqueued_jobs 1 do

--- a/test/controllers/personal_informations/machines_controller_test.rb
+++ b/test/controllers/personal_informations/machines_controller_test.rb
@@ -36,7 +36,7 @@ class PersonalInformations::MachinesControllerTest < ActionDispatch::Integration
 
     assert_response :success
     assert_select "td div", text: "田植機"
-    assert_select "td", text: /2\.5\(時間\)/
+    assert_select "td", text: /2\.50\(時間\)/
     assert_no_match "別世帯軽トラ", response.body
   end
 

--- a/test/controllers/works/trucks_inputs_controller_test.rb
+++ b/test/controllers/works/trucks_inputs_controller_test.rb
@@ -20,7 +20,7 @@ class Works::TrucksInputsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "input[name=?][type=number][min=?][max=?][step=?][required=required][value=?]",
-                  "machine_hours[#{@home1_truck.id}][#{work_result.id}]", "0", "9.5", "0.5", "1.5"
+                  "machine_hours[#{@home1_truck.id}][#{work_result.id}]", "0", "9.5", "0.25", "1.50"
     assert_select "input[name^=?]", "machine_hours[#{@home6_truck.id}]", count: 0
   end
 
@@ -33,7 +33,7 @@ class Works::TrucksInputsControllerTest < ActionDispatch::IntegrationTest
     get works_trucks_path, params: { work_kind_id: work_kinds(:work_kind_shirokaki).id, month: "2015-02-01" }
 
     assert_response :success
-    assert_select "input[name=?][value=?]", "machine_hours[#{@home1_truck.id}][#{second_work_result.id}]", "2.0"
+    assert_select "input[name=?][value=?]", "machine_hours[#{@home1_truck.id}][#{second_work_result.id}]", "2.00"
     assert_select "input[name=?]", "machine_hours[#{@home1_truck.id}][#{first_work_result.id}]", count: 0
   end
 

--- a/test/controllers/works/trucks_registration_controller_test.rb
+++ b/test/controllers/works/trucks_registration_controller_test.rb
@@ -69,7 +69,7 @@ class Works::TrucksRegistrationControllerTest < ActionDispatch::IntegrationTest
     assert_nil MachineResult.find_by(machine: @home1_truck, work_result: other_home_work_result)
   end
 
-  test "範囲外または 0.5 刻みではない賃借量は無視する" do
+  test "範囲外または 0.25 刻みではない賃借量は無視する" do
     work = create_work(Date.new(2015, 2, 5), work_kinds(:work_kind_shirokaki))
     work_result = create_work_result(work, workers(:worker1))
     existing_result = MachineResult.create!(machine: @home1_truck, work_result: work_result, hours: 1.5)
@@ -81,7 +81,7 @@ class Works::TrucksRegistrationControllerTest < ActionDispatch::IntegrationTest
         machine_hours: {
           @home1_truck.id => {
             work_result.id => "10.0",
-            invalid_work_result.id => "1.25"
+            invalid_work_result.id => "1.1"
           }
         }
       )

--- a/test/fixtures/machine_results.yml
+++ b/test/fixtures/machine_results.yml
@@ -8,7 +8,7 @@
 #  fixed_price(確定稼動単価)      :decimal(5, )
 #  fixed_quantity(確定稼動量)     :decimal(6, 2)
 #  fuel_usage(燃料使用量)         :decimal(5, 2)    default(0.0), not null
-#  hours(稼動時間)                :decimal(3, 1)    default(0.0), not null
+#  hours(稼動時間)                :decimal(4, 2)    default(0.0), not null
 #  created_at                     :datetime
 #  updated_at                     :datetime
 #  fixed_adjust_id(確定稼動単位)  :integer

--- a/test/models/machine_result_test.rb
+++ b/test/models/machine_result_test.rb
@@ -8,7 +8,7 @@
 #  fixed_price(確定稼動単価)      :decimal(5, )
 #  fixed_quantity(確定稼動量)     :decimal(6, 2)
 #  fuel_usage(燃料使用量)         :decimal(5, 2)    default(0.0), not null
-#  hours(稼動時間)                :decimal(3, 1)    default(0.0), not null
+#  hours(稼動時間)                :decimal(4, 2)    default(0.0), not null
 #  created_at                     :datetime
 #  updated_at                     :datetime
 #  fixed_adjust_id(確定稼動単位)  :integer

--- a/test/system/fixes_test.rb
+++ b/test/system/fixes_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+class FixesTest < ApplicationSystemTestCase
+  ORIGINAL_SUM_MACHINES_AMOUNT = Work.instance_method(:sum_machines_amount)
+
+  setup do
+    @user = users(:users1)
+  end
+
+  teardown do
+    Work.define_method(:sum_machines_amount, ORIGINAL_SUM_MACHINES_AMOUNT)
+  end
+
+  test "新規確定で機械使用料がカンマ区切りのまま表示され、選択時の合計も正しく計算される" do
+    work1 = works(:work_no_fix1)
+    work2 = works(:work_no_fix2)
+    amounts = { work1.id => BigDecimal("5250"), work2.id => BigDecimal("3400") }
+    Work.define_method(:sum_machines_amount) { amounts.fetch(id, 0) }
+
+    login_as(@user)
+    visit new_fix_path
+
+    assert_selector "#machine_#{work1.id}", text: "5,250"
+    assert_selector "#machine_#{work2.id}", text: "3,400"
+    assert_selector "#total_machine", text: "0"
+
+    click_on "全選択", match: :first
+
+    assert_selector "#total_machine", text: "8,650"
+
+    click_on "全解除", match: :first
+
+    assert_selector "#total_machine", text: "0"
+  end
+
+  private
+
+  def login_as(user)
+    visit root_path
+    fill_in "login_name", with: user.login_name
+    fill_in "password", with: "password"
+    click_button "認証する"
+    assert_selector "a", exact_text: "作業日報管理"
+  end
+end


### PR DESCRIPTION
## Summary
- 交通費(自家用車賃借料)の入力(works/:work_id/machines/new, works/trucks)を15分(0.25時間)単位に変更し、表示・入力を小数2位(0.00)形式に統一
- machine_results.hours カラムを小数2位まで保持できるよう変更
- 世帯別機械一覧(/machine_results)の時間表示も小数2位に修正
- 確定画面(fixes/new)の機械使用料表示のバグ(桁落ちして極端に小さい金額になる)を修正、列幅とレイアウトも調整
- 関連のテスト(コントローラー・システムテスト)を追加

Closes #1119