### PR TITLE
#1117 日報検証ポップアップの土地表示を機械利用表示に変更しデザインを刷新

### DIFF
--- a/app/controllers/work_verifications_controller.rb
+++ b/app/controllers/work_verifications_controller.rb
@@ -11,7 +11,7 @@ class WorkVerificationsController < ApplicationController
   def show
     @work = @work.decorate
     @results = WorkResultDecorator.decorate_collection(@work.work_results.includes(:worker) || [])
-    @work_lands = WorkLandDecorator.decorate_collection(@work.work_lands.includes(:land) || [])
+    @machine_results = MachineResultDecorator.decorate_collection(@work.machine_results.includes(machine: [:machine_type, :owner], work_result: :worker) || [])
     respond_to_format(:html, partial: "show")
   end
 

--- a/app/views/work_verifications/_show.html.erb
+++ b/app/views/work_verifications/_show.html.erb
@@ -1,51 +1,66 @@
 <div class="modal-body">
-  <% xx = 2; yy = (([current_organization.workers_count, @results.count].max - 1) / xx + 1) %>
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col-md-1"><span class="border border-dark small"><%= @work.id %></span></div>
-      <div class="col-md-11 h3"><%= @work.worked_at %>&nbsp;天候(<%= @work.weather_name %>)</div>
+  <div class="d-flex justify-content-between align-items-center flex-wrap mb-2">
+    <div>
+      <span class="badge bg-secondary">No.<%= @work.id %></span>
+      <span class="fs-4 fw-bold ms-2"><%= @work.worked_at %></span>
+      <span class="text-muted ms-2">天候: <%= @work.weather_name %></span>
     </div>
-    <div class="row">
-      <div class="col-md-12 h4"><%= @work.start_at %>〜<%= @work.end_at %></div>
-    </div>
-    <div class="row">
-      <div class="col-md-4 h5"><%= @work.work_type_name%></div>
-      <div class="col-md-8 h5"><%= @work.name %></div>
-    </div>
-    <div class="row">
-      <h3>作業者</h3>
-    </div>
-    <% yy.times do |i| %>
-      <div class="row">
-        <% xx.times do |x| %>
-          <% j = i + yy * x %>
-          <div class="col-md-1 text-right border border-primary"><%= j + 1 %></div>
-          <div class="col-md-4 text-left border border-primary"><%=raw @results[j] ? @results[j].worker_name(current_organization) : "" %></div>
-          <div class="col-md-1 text-right border border-primary"><%=raw @results[j] ? @results[j].hours : "" %></div>
-        <% end %>
-      </div>
-    <% end %>
-    <div class="row">
-      <h3>土地</h3>
-    </div>
-    <% xx = 3; yy = ([current_organization.lands_count, @work_lands.count].max / xx + 1) %>
-    <% total_area = 0 %>
-    <% yy.times do |i| %>
-      <div class="row">
-        <% xx.times do |x| %>
-        <% j = i + yy * x %>
-          <% if j == (yy * xx - 1) %>
-            <div class="col-md-2 text-center border border-info small">合計</div>
-            <div class="col-md-2 text-right border border-info small"><%= sprintf("%.2f", total_area) %></div>
-          <% else %>
-            <div class="col-md-1 text-right border border-info small"><%= j + 1 %></div>
-            <div class="col-md-3 text-left border border-info small"><%=raw @work_lands[j] ? @work_lands[j].place : "" %></div>
-            <% total_area += @work_lands[j].land.area if @work_lands[j]  %>
-          <% end %>
-        <% end %>
-      </div>
-    <% end %>
+    <div class="text-muted"><%= @work.start_at %> 〜 <%= @work.end_at %></div>
   </div>
+  <div class="mb-3">
+    <span class="badge bg-info text-dark"><%= @work.work_type_name %></span>
+    <span class="fw-bold ms-2"><%= @work.name %></span>
+  </div>
+
+  <h6 class="border-bottom pb-1 mb-2">作業者</h6>
+  <div class="table-responsive mb-3">
+    <table class="table table-sm table-striped table-bordered mb-0">
+      <thead>
+        <tr>
+          <th style="width:3em;">No.</th>
+          <th>氏名</th>
+          <th class="numeric" style="width:6em;">時間</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @results.each_with_index do |result, i| %>
+          <tr>
+            <td><%= i + 1 %></td>
+            <td><%=raw result.worker_name(current_organization) %></td>
+            <td class="numeric"><%= result.hours %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <h6 class="border-bottom pb-1 mb-2">機械利用</h6>
+  <% if @machine_results.present? %>
+    <div class="table-responsive">
+      <table class="table table-sm table-striped table-bordered mb-0">
+        <thead>
+          <tr>
+            <th>種別</th>
+            <th>機械</th>
+            <th>オペレーター</th>
+            <th class="numeric" style="width:6em;">稼動時間</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @machine_results.each do |machine_result| %>
+            <tr>
+              <td><%= machine_result.machine.type_name %></td>
+              <td><%= machine_result.machine.alias_name %></td>
+              <td><%= machine_result.work_result.worker.name %></td>
+              <td class="numeric"><%= sprintf("%.2f", machine_result.hours) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-muted mb-0">機械の利用はありません。</p>
+  <% end %>
 </div>
 <div class="modal-footer">
   <% if @work.checkers.include?(current_user.worker) %>

--- a/test/fixtures/machine_results.yml
+++ b/test/fixtures/machine_results.yml
@@ -4052,3 +4052,11 @@ machine_result_stat_2019_1:
   hours: 2.5
   created_at: '2019-01-01 08:53:39'
   updated_at: '2019-01-01 08:53:39'
+
+machine_result_work_verifying:
+  machine_id: 4
+  work_result_id: 5247
+  display_order: 1
+  hours: 4.0
+  created_at: '2015-03-22 01:37:20.287444'
+  updated_at: '2015-03-22 01:37:20.287444'

--- a/test/system/work_verifications_test.rb
+++ b/test/system/work_verifications_test.rb
@@ -26,6 +26,10 @@ class WorkVerificationsTest < ApplicationSystemTestCase
     # 検証対象の作業日報の詳細を確認
     within '.modal-dialog' do
       assert_text @work.id
+      assert_no_text '土地'
+      assert_text '機械利用'
+      assert_text 'トラクター'
+      assert_text 'MZ65幅広T#3'
     end
 
     # 検証実行ボタンをクリック

--- a/test/system/work_verifications_test.rb
+++ b/test/system/work_verifications_test.rb
@@ -30,6 +30,8 @@ class WorkVerificationsTest < ApplicationSystemTestCase
       assert_text '機械利用'
       assert_text 'トラクター'
       assert_text 'MZ65幅広T#3'
+      assert_text '荒木 直行'
+      assert_text '4.00'
     end
 
     # 検証実行ボタンをクリック


### PR DESCRIPTION
## Summary
- 日報検証(/work_verifications)ポップアップの「土地」表示を廃止(検証観点で不要なため)
- 代わりに「機械利用」情報(種別・機械・オペレーター・稼動時間)を表示するよう変更
- あわせてポップアップのデザインを刷新(旧来の手組みグリッドレイアウトをBootstrapテーブルベースに変更)

issue #1117

## Test plan
- [x] `bin/rails test test/controllers/work_verifications_controller_test.rb`
- [x] `bin/rails test test/system/work_verifications_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)